### PR TITLE
Changed postgres port to 5439

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Then, register a server with the following details:
 
 - Name: **userapipostgres** (can be anything though)
 - Host name/address: **userapipostgres**
-- Port: **5432**
+- Port: **5439**
 - Username: **root**
 - Password: **root**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nuvalence User Management API build and run:
 
-## Build:
+## Build/Run Locally:
 ```./gradlew clean build composeUp```
 
 You can view the state of the database afterwards by going to the local instance of [pgAdmin](http://localhost:5050) with the following credentials:
@@ -18,6 +18,8 @@ Then, register a server with the following details:
 
 NOTE: These details are also in the [docker-compose.yml](./docker-compose.yml) file.
 
+[view docs](http://localhost:8080/swagger-ui.html)
+
 The app can be brought down via:
 
 ```./gradlew composeDown```
@@ -27,11 +29,6 @@ The app can be brought down via:
 
 ### Documentation
  - [tools and frameworks](./docs/tools.md)
-
-## Run Locally
-1. build: `./gradlew clean build jibDockerBuild`
-2. exec: `docker-compose up`
-3. [view docs](http://localhost:8080/swagger-ui.html)
 
 ## Cerbos
 The Nuvalence User Management has a dependency to a Cerbos instance with the Cerbos Admin API configured and running for updates to roles and permissions as well as validating permissions. You can view the Cerbos docs [here](https://docs.cerbos.dev/cerbos/latest/index.html).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - POSTGRES_DB=userapipostgres
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=root
+      - PGPORT=5439
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=root
       - PGPORT=5439
+      - PGDATABASE=userapipostgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 10s

--- a/service/src/main/resources/application-local.yml
+++ b/service/src/main/resources/application-local.yml
@@ -2,14 +2,14 @@ spring:
 
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://userapipostgres:5432/userapipostgres?stringtype=unspecified
+    url: jdbc:postgresql://userapipostgres:5439/userapipostgres?stringtype=unspecified
     username: root
     password: root
   liquibase:
     enabled: true
     change-log: classpath:db/liquibase-changelog.xml
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://userapipostgres:5432/userapipostgres?stringtype=unspecified
+    url: jdbc:postgresql://userapipostgres:5439/userapipostgres?stringtype=unspecified
     user: root
     password: root
   jpa:


### PR DESCRIPTION
## Description
Previously, the internal port for docker was kept to 5432 but externally it was set to 5439. This was done to not have any port collisions with other postgres instances that have the default postgres port set (5432). This change will make the port be 5439 both internally and externally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (documentation only, will not require redeployment)
- [ ] Refactor or cleanup (functionality unchanged)
Minor
- [ ] New feature (non-breaking change which adds functionality)
Major
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any do not apply, leave a description indicating why -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
<!-- - [ ] My change requires a version increment in gradle.properties -->
<!-- - [ ] My change requires redeployment of the API Gateway Deployment after the pipeline succeeds -->
- [x] I have confirmed all acceptance criteria defined by the story have been met