### PR TITLE
Add support for custom fields

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -38,6 +38,14 @@
         <property name="id" value="printStackTrace"/>
         <property name="files" value=".*[/\\](test|functionalTest)[/\\].*\.java"/>
     </module>
+    <module name="SuppressionSingleFilter">
+        <property name="checks" value="ClassDataAbstractionCoupling"/>
+        <property name="files" value=".*[/\\]test[/\\].*\.java"/>
+    </module>
+    <module name="SuppressionSingleFilter">
+        <property name="checks" value="ClassFanOutComplexity"/>
+        <property name="files" value=".*[/\\]test[/\\].*\.java"/>
+    </module>
 
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
@@ -51,8 +59,10 @@
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
 
+    <module name="SuppressWarningsFilter" />
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/>
+        <module name="SuppressWarningsHolder"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -52,6 +52,8 @@ dockerCompose {
 	tcpPortsToIgnoreWhenWaiting = [5439]
 }
 
+composeUp.dependsOn build
+
 test {
 	useJUnitPlatform()
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'com.vladmihalcea:hibernate-types-52:2.16.1'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/service/src/main/java/io/nuvalence/user/management/api/service/controller/CustomFieldApiDelegateImpl.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/controller/CustomFieldApiDelegateImpl.java
@@ -1,0 +1,67 @@
+package io.nuvalence.user.management.api.service.controller;
+
+import io.nuvalence.user.management.api.service.generated.controllers.CustomFieldsApiDelegate;
+import io.nuvalence.user.management.api.service.generated.models.CreateCustomFieldDTO;
+import io.nuvalence.user.management.api.service.generated.models.CreateOrUpdateCustomFieldOptionDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldOptionDTO;
+import io.nuvalence.user.management.api.service.generated.models.UpdateCustomFieldDTO;
+import io.nuvalence.user.management.api.service.service.CustomFieldService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Controller for Custom Field API.
+ */
+
+@Service
+@RequiredArgsConstructor
+public class CustomFieldApiDelegateImpl implements CustomFieldsApiDelegate {
+    private final CustomFieldService customFieldService;
+
+    @Override
+    public Optional<NativeWebRequest> getRequest() {
+        return CustomFieldsApiDelegate.super.getRequest();
+    }
+
+    @Override
+    public ResponseEntity<List<CustomFieldDTO>> getAllCustomFields() {
+        return customFieldService.getAllCustomFields();
+    }
+
+    @Override
+    public ResponseEntity<Void> addCustomField(CreateCustomFieldDTO customField) {
+        return customFieldService.addCustomField(customField);
+    }
+
+    @Override
+    public ResponseEntity<CustomFieldDTO> getCustomFieldById(UUID id) {
+        return customFieldService.getCustomFieldById(id);
+    }
+
+    @Override
+    public ResponseEntity<Void> updateCustomField(UUID id, UpdateCustomFieldDTO customField) {
+        return customFieldService.updateCustomField(id, customField);
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteCustomField(UUID id) {
+        return customFieldService.deleteCustomField(id);
+    }
+
+    @Override
+    public ResponseEntity<List<CustomFieldOptionDTO>> getOptionsForCustomField(UUID id) {
+        return customFieldService.getOptionsForCustomField(id);
+    }
+
+    @Override
+    public ResponseEntity<Void> updateCustomFieldOptions(UUID id, List<CreateOrUpdateCustomFieldOptionDTO> options) {
+        return customFieldService.updateCustomFieldOptions(id, options);
+    }
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/controller/UserApiDelegateImpl.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/controller/UserApiDelegateImpl.java
@@ -3,6 +3,7 @@ package io.nuvalence.user.management.api.service.controller;
 import io.nuvalence.user.management.api.service.entity.UserPreferenceEntity;
 import io.nuvalence.user.management.api.service.generated.controllers.UserApiDelegate;
 import io.nuvalence.user.management.api.service.generated.models.ApplicationPreferenceDTO;
+import io.nuvalence.user.management.api.service.generated.models.CreateOrUpdateUserCustomFieldDTO;
 import io.nuvalence.user.management.api.service.generated.models.RoleDTO;
 import io.nuvalence.user.management.api.service.generated.models.UserCreationRequest;
 import io.nuvalence.user.management.api.service.generated.models.UserDTO;
@@ -110,6 +111,11 @@ public class UserApiDelegateImpl implements UserApiDelegate {
                                                              ApplicationPreferenceDTO userPreferences) {
         userPreferenceService.updateApplicationPreferencesById(id, appId, userPreferences);
         return ResponseEntity.ok().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> updateUserCustomFieldValue(UUID id, CreateOrUpdateUserCustomFieldDTO customField) {
+        return userService.updateCustomField(id, customField);
     }
 
 }

--- a/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldDataTypeEntity.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldDataTypeEntity.java
@@ -22,8 +22,8 @@ import javax.persistence.Table;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "data_type")
-public class DataTypeEntity {
+@Table(name = "custom_field_data_type")
+public class CustomFieldDataTypeEntity {
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")

--- a/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldEntity.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldEntity.java
@@ -1,0 +1,49 @@
+package io.nuvalence.user.management.api.service.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * Represents a single CustomField.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "custom_field")
+public class CustomFieldEntity {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")
+    @Type(type = "uuid-char")
+    @Column(name = "id", length = 36, insertable = false, updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "custom_field_type_id", nullable = false)
+    private CustomFieldTypeEntity customFieldType;
+
+    @ManyToOne
+    @JoinColumn(name = "data_type_id")
+    private DataTypeEntity dataType;
+
+    @Column(name = "display_text", nullable = false, length = 255)
+    private String displayText;
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldEntity.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldEntity.java
@@ -1,12 +1,14 @@
 package io.nuvalence.user.management.api.service.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
+import java.util.List;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -14,6 +16,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 /**
@@ -21,6 +24,7 @@ import javax.persistence.Table;
  */
 @Getter
 @Setter
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
@@ -38,12 +42,15 @@ public class CustomFieldEntity {
 
     @ManyToOne
     @JoinColumn(name = "custom_field_type_id", nullable = false)
-    private CustomFieldTypeEntity customFieldType;
+    private CustomFieldTypeEntity type;
 
     @ManyToOne
-    @JoinColumn(name = "data_type_id")
-    private DataTypeEntity dataType;
+    @JoinColumn(name = "custom_field_data_type_id")
+    private CustomFieldDataTypeEntity dataType;
 
     @Column(name = "display_text", nullable = false, length = 255)
     private String displayText;
+
+    @OneToMany(mappedBy = "customField")
+    private List<CustomFieldOptionEntity> options;
 }

--- a/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldOptionEntity.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldOptionEntity.java
@@ -1,0 +1,45 @@
+package io.nuvalence.user.management.api.service.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * Represents a single CustomFieldOption.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "custom_field_option")
+public class CustomFieldOptionEntity {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")
+    @Type(type = "uuid-char")
+    @Column(name = "id", length = 36, insertable = false, updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "custom_field_id")
+    private CustomFieldEntity customField;
+
+    @Column(name = "option_value", nullable = false, length = 255)
+    private String optionValue;
+
+    @Column(name = "display_text", nullable = false, length = 255)
+    private String displayText;
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldTypeEntity.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/entity/CustomFieldTypeEntity.java
@@ -1,0 +1,36 @@
+package io.nuvalence.user.management.api.service.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Represents a single CustomFieldType.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "custom_field_type")
+public class CustomFieldTypeEntity {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")
+    @Type(type = "uuid-char")
+    @Column(name = "id", length = 36, insertable = false, updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "type", nullable = false, length = 255)
+    private String type;
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/entity/DataTypeEntity.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/entity/DataTypeEntity.java
@@ -1,0 +1,36 @@
+package io.nuvalence.user.management.api.service.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Represents a single DataType.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "data_type")
+public class DataTypeEntity {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")
+    @Type(type = "uuid-char")
+    @Column(name = "id", length = 36, insertable = false, updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "type", nullable = false, length = 255)
+    private String type;
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/entity/UserCustomFieldEntity.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/entity/UserCustomFieldEntity.java
@@ -1,0 +1,63 @@
+package io.nuvalence.user.management.api.service.entity;
+
+import com.vladmihalcea.hibernate.type.json.JsonType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * Represents a single UserCustomField.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "user_custom_field")
+@TypeDefs({
+        @TypeDef(name = "json", typeClass = JsonType.class)
+})
+public class UserCustomFieldEntity {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")
+    @Type(type = "uuid-char")
+    @Column(name = "id", length = 36, insertable = false, updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @ManyToOne
+    @JoinColumn(name = "custom_field_id")
+    private CustomFieldEntity customField;
+
+    @Column(name = "custom_field_value_string", nullable = true, length = 255)
+    private String customFieldValueString;
+
+    @Column(name = "custom_field_value_int", nullable = true)
+    private Integer customFieldValueInt;
+
+    @Type(type = "json")
+    @Column(name = "custom_field_value_json", nullable = true, columnDefinition = "json")
+    private String customFieldValueJson;
+
+    @Column(name = "custom_field_value_datetime", nullable = true)
+    private LocalDateTime customFieldValueDateTime;
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/entity/UserCustomFieldEntity.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/entity/UserCustomFieldEntity.java
@@ -2,6 +2,7 @@ package io.nuvalence.user.management.api.service.entity;
 
 import com.vladmihalcea.hibernate.type.json.JsonType;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,7 +11,7 @@ import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -25,6 +26,7 @@ import javax.persistence.Table;
  */
 @Getter
 @Setter
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
@@ -59,5 +61,5 @@ public class UserCustomFieldEntity {
     private String customFieldValueJson;
 
     @Column(name = "custom_field_value_datetime", nullable = true)
-    private LocalDateTime customFieldValueDateTime;
+    private OffsetDateTime customFieldValueDateTime;
 }

--- a/service/src/main/java/io/nuvalence/user/management/api/service/entity/UserEntity.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/entity/UserEntity.java
@@ -49,4 +49,7 @@ public class UserEntity {
 
     @OneToMany(mappedBy = "user")
     private List<UserRoleEntity> userRoleEntities;
+
+    @OneToMany(mappedBy = "user")
+    private List<UserCustomFieldEntity> customFields;
 }

--- a/service/src/main/java/io/nuvalence/user/management/api/service/enums/CustomFieldDataType.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/enums/CustomFieldDataType.java
@@ -1,0 +1,41 @@
+package io.nuvalence.user.management.api.service.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents the possible data types for custom fields.
+ */
+public enum CustomFieldDataType {
+    STRING("string"),
+    INT("int"),
+    JSON("json"),
+    DATETIME("datetime");
+
+    @JsonValue
+    private final String type;
+
+    CustomFieldDataType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return this.type;
+    }
+
+    /**
+     * Converts between strings and CustomFieldDataType enum.
+     *
+     * @param text the text representation of the enum.
+     * @return an enum value.
+     */
+    public static CustomFieldDataType fromText(String text) {
+        for (CustomFieldDataType dataType : CustomFieldDataType.values()) {
+            if (dataType.toString().equalsIgnoreCase(text)) {
+                return dataType;
+            }
+        }
+
+        return STRING;
+    }
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/enums/CustomFieldType.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/enums/CustomFieldType.java
@@ -6,7 +6,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Represents the possible types for custom fields.
  */
 public enum CustomFieldType {
-    DROP_DOWN_LIST("drop_down_list");
+    DROP_DOWN_LIST("drop_down_list"),
+    TEXT_FIELD("text_field");
 
     @JsonValue
     private final String type;
@@ -33,6 +34,6 @@ public enum CustomFieldType {
             }
         }
 
-        return DROP_DOWN_LIST;
+        return TEXT_FIELD;
     }
 }

--- a/service/src/main/java/io/nuvalence/user/management/api/service/enums/CustomFieldType.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/enums/CustomFieldType.java
@@ -1,0 +1,38 @@
+package io.nuvalence.user.management.api.service.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents the possible types for custom fields.
+ */
+public enum CustomFieldType {
+    DROP_DOWN_LIST("drop_down_list");
+
+    @JsonValue
+    private final String type;
+
+    CustomFieldType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return this.type;
+    }
+
+    /**
+     * Converts between strings and CustomFieldType enum.
+     *
+     * @param text the text representation of the enum.
+     * @return an enum value.
+     */
+    public static CustomFieldType fromText(String text) {
+        for (CustomFieldType type : CustomFieldType.values()) {
+            if (type.toString().equalsIgnoreCase(text)) {
+                return type;
+            }
+        }
+
+        return DROP_DOWN_LIST;
+    }
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/mapper/CustomFieldMapper.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/mapper/CustomFieldMapper.java
@@ -7,6 +7,7 @@ import io.nuvalence.user.management.api.service.generated.models.CustomFieldDTO;
 import io.nuvalence.user.management.api.service.generated.models.CustomFieldOptionDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -24,8 +25,8 @@ public interface CustomFieldMapper {
      * @param entity a custom field entity
      * @return custom field model
      */
-    @Mapping(source = "entity.type.type", target = "type")
-    @Mapping(source = "entity.dataType.type", target = "dataType")
+    @Mapping(source = "entity.type.type", target = "type", qualifiedByName = "customFieldType")
+    @Mapping(source = "entity.dataType.type", target = "dataType", qualifiedByName = "customFieldDataType")
     CustomFieldDTO convertEntityToDto(CustomFieldEntity entity);
 
     /**
@@ -61,4 +62,14 @@ public interface CustomFieldMapper {
     @Mapping(target = "displayText", source = "dto.displayText")
     CustomFieldOptionEntity convertOptionDtoToOptionEntity(CreateOrUpdateCustomFieldOptionDTO dto,
                                                            CustomFieldEntity customField);
+
+    @Named("customFieldType")
+    default CustomFieldDTO.TypeEnum toCustomFieldType(String type) {
+        return CustomFieldDTO.TypeEnum.fromValue(type);
+    }
+
+    @Named("customFieldDataType")
+    default CustomFieldDTO.DataTypeEnum toCustomFieldDataType(String type) {
+        return CustomFieldDTO.DataTypeEnum.fromValue(type);
+    }
 }

--- a/service/src/main/java/io/nuvalence/user/management/api/service/mapper/CustomFieldMapper.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/mapper/CustomFieldMapper.java
@@ -1,0 +1,64 @@
+package io.nuvalence.user.management.api.service.mapper;
+
+import io.nuvalence.user.management.api.service.entity.CustomFieldEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldOptionEntity;
+import io.nuvalence.user.management.api.service.generated.models.CreateOrUpdateCustomFieldOptionDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldOptionDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Maps between CustomFieldEntity and CustomFieldDTO.
+ */
+
+@Mapper
+public interface CustomFieldMapper {
+    CustomFieldMapper INSTANCE = Mappers.getMapper(CustomFieldMapper.class);
+
+    /**
+     * Maps {@link CustomFieldEntity} to
+     * {@link CustomFieldDTO}.
+     *
+     * @param entity a custom field entity
+     * @return custom field model
+     */
+    @Mapping(source = "entity.type.type", target = "type")
+    @Mapping(source = "entity.dataType.type", target = "dataType")
+    CustomFieldDTO convertEntityToDto(CustomFieldEntity entity);
+
+    /**
+     * Maps {@link CustomFieldEntity} to
+     * {@link CustomFieldOptionDTO}.
+     *
+     * @param entity a custom field option entity
+     * @return custom field option model
+     */
+    CustomFieldOptionDTO convertOptionEntityToOptionDto(CustomFieldOptionEntity entity);
+
+    /**
+     * Maps {@link CustomFieldOptionDTO} to
+     * {@link CustomFieldOptionEntity}.
+     *
+     * @param dto a custom field option DTO
+     * @param customField the custom field to associate the option to
+     * @return a custom field option entity
+     */
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "displayText", source = "dto.displayText")
+    CustomFieldOptionEntity convertOptionDtoToOptionEntity(CustomFieldOptionDTO dto, CustomFieldEntity customField);
+
+    /**
+     * Maps {@link CreateOrUpdateCustomFieldOptionDTO} to
+     * {@link CustomFieldOptionEntity}.
+     *
+     * @param dto a custom field option DTO
+     * @param customField the custom field to associate the option to
+     * @return a custom field option entity
+     */
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "displayText", source = "dto.displayText")
+    CustomFieldOptionEntity convertOptionDtoToOptionEntity(CreateOrUpdateCustomFieldOptionDTO dto,
+                                                           CustomFieldEntity customField);
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/mapper/UserEntityMapper.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/mapper/UserEntityMapper.java
@@ -24,6 +24,7 @@ public interface UserEntityMapper {
      */
     @Mapping(target = "preferences", ignore = true)
     @Mapping(target = "assignedRoles", ignore = true)
+    @Mapping(target = "customFields", ignore = true)
     UserDTO convertUserEntityToUserModel(UserEntity userEntity);
 
     /**

--- a/service/src/main/java/io/nuvalence/user/management/api/service/mapper/UserEntityMapper.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/mapper/UserEntityMapper.java
@@ -35,6 +35,7 @@ public interface UserEntityMapper {
      */
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "userRoleEntities", ignore = true)
+    @Mapping(target = "customFields", ignore = true)
     UserEntity convertUserModelToUserEntity(UserDTO user);
 
     /**
@@ -46,5 +47,7 @@ public interface UserEntityMapper {
      */
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "userRoleEntities", ignore = true)
+    @Mapping(target = "customFields", ignore = true)
+    @Mapping(target = "id", ignore = true)
     UserEntity convertUserCreationRequestToUserEntity(UserCreationRequest user);
 }

--- a/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldDataTypeRepository.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldDataTypeRepository.java
@@ -1,0 +1,20 @@
+package io.nuvalence.user.management.api.service.repository;
+
+import io.nuvalence.user.management.api.service.entity.CustomFieldDataTypeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for CustomFieldDataType.
+ */
+
+@Repository
+public interface CustomFieldDataTypeRepository extends JpaRepository<CustomFieldDataTypeEntity, UUID> {
+    @Query(value = "SELECT * FROM custom_field_data_type WHERE type = :type", nativeQuery = true)
+    Optional<CustomFieldDataTypeEntity> findFirstByType(@Param("type") String type);
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldOptionRepository.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldOptionRepository.java
@@ -1,0 +1,20 @@
+package io.nuvalence.user.management.api.service.repository;
+
+import io.nuvalence.user.management.api.service.entity.CustomFieldOptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Repository for CustomFieldOption.
+ */
+
+@Repository
+public interface CustomFieldOptionRepository extends JpaRepository<CustomFieldOptionEntity, UUID> {
+    @Query(value = "SELECT * FROM custom_field_option WHERE custom_field_id = :customFieldId", nativeQuery = true)
+    List<CustomFieldOptionEntity> findByCustomField(@Param("customFieldId") UUID customFieldId);
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldRepository.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldRepository.java
@@ -17,4 +17,8 @@ import java.util.UUID;
 public interface CustomFieldRepository extends JpaRepository<CustomFieldEntity, UUID> {
     @Query(value = "SELECT * FROM custom_field WHERE name = :name", nativeQuery = true)
     Optional<CustomFieldEntity> findFirstByName(@Param("name") String name);
+
+    @Query(value = "SELECT * FROM custom_field WHERE name = :name AND id <> :customFieldId", nativeQuery = true)
+    Optional<CustomFieldEntity> findFirstByNameAndIdNot(@Param("name") String name,
+                                                        @Param("customFieldId") UUID customFieldId);
 }

--- a/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldRepository.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldRepository.java
@@ -1,0 +1,20 @@
+package io.nuvalence.user.management.api.service.repository;
+
+import io.nuvalence.user.management.api.service.entity.CustomFieldEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for CustomField.
+ */
+
+@Repository
+public interface CustomFieldRepository extends JpaRepository<CustomFieldEntity, UUID> {
+    @Query(value = "SELECT * FROM custom_field WHERE name = :name", nativeQuery = true)
+    Optional<CustomFieldEntity> findFirstByName(@Param("name") String name);
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldTypeRepository.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/repository/CustomFieldTypeRepository.java
@@ -1,0 +1,20 @@
+package io.nuvalence.user.management.api.service.repository;
+
+import io.nuvalence.user.management.api.service.entity.CustomFieldTypeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for CustomFieldType.
+ */
+
+@Repository
+public interface CustomFieldTypeRepository extends JpaRepository<CustomFieldTypeEntity, UUID> {
+    @Query(value = "SELECT * FROM custom_field_type WHERE type = :type", nativeQuery = true)
+    Optional<CustomFieldTypeEntity> findFirstByType(@Param("type") String type);
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/repository/UserCustomFieldRepository.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/repository/UserCustomFieldRepository.java
@@ -1,0 +1,28 @@
+package io.nuvalence.user.management.api.service.repository;
+
+import io.nuvalence.user.management.api.service.entity.UserCustomFieldEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for UserCustomField.
+ */
+
+@Repository
+public interface UserCustomFieldRepository extends JpaRepository<UserCustomFieldEntity, UUID> {
+    @Query(value = "SELECT * FROM user_custom_field WHERE custom_field_id = :customFieldId", nativeQuery = true)
+    List<UserCustomFieldEntity> findAllByCustomField(@Param("customFieldId") UUID customFieldId);
+
+    @Query(value = "SELECT * FROM user_custom_field WHERE user_id = :userId", nativeQuery = true)
+    List<UserCustomFieldEntity> findAllByUserId(@Param("userId") UUID userId);
+
+    @Query(value = "SELECT * FROM user_custom_field WHERE user_id = :userId AND custom_field_id = :customFieldId",
+            nativeQuery = true)
+    Optional<UserCustomFieldEntity> findFirstByUserAndCustomField(UUID userId, UUID customFieldId);
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/repository/UserCustomFieldRepository.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/repository/UserCustomFieldRepository.java
@@ -24,5 +24,6 @@ public interface UserCustomFieldRepository extends JpaRepository<UserCustomField
 
     @Query(value = "SELECT * FROM user_custom_field WHERE user_id = :userId AND custom_field_id = :customFieldId",
             nativeQuery = true)
-    Optional<UserCustomFieldEntity> findFirstByUserAndCustomField(UUID userId, UUID customFieldId);
+    Optional<UserCustomFieldEntity> findFirstByUserAndCustomField(@Param("userId") UUID userId,
+                                                                  @Param("customFieldId") UUID customFieldId);
 }

--- a/service/src/main/java/io/nuvalence/user/management/api/service/service/CustomFieldService.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/service/CustomFieldService.java
@@ -26,7 +26,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -231,38 +230,14 @@ public class CustomFieldService {
             throw new BusinessLogicException("The custom field is not a drop-down type.");
         }
 
-        List<CustomFieldOptionEntity> existingCustomFieldOptions = customFieldOptionRepository
-                .findByCustomField(customFieldId);
-
         List<CustomFieldOptionEntity> optionEntities = options
                 .stream().map(o -> CustomFieldMapper.INSTANCE.convertOptionDtoToOptionEntity(o, customField.get()))
                 .collect(Collectors.toList());
 
-        customFieldOptionRepository.deleteAll(existingCustomFieldOptions);
+        customFieldOptionRepository.deleteAll(customField.get().getOptions());
         customFieldOptionRepository.saveAll(optionEntities);
 
         return ResponseEntity.ok().build();
-    }
-
-    private CustomFieldDTO mapCustomFieldEntityToCustomFieldDto(CustomFieldEntity entity) {
-        CustomFieldDTO customField = new CustomFieldDTO();
-        customField.setId(entity.getId());
-        customField.setName(entity.getName());
-        customField.setDisplayText(entity.getDisplayText());
-        customField.setDataType(CustomFieldDTO.DataTypeEnum.fromValue(entity.getDataType().getType()));
-        customField.setType(CustomFieldDTO.TypeEnum.fromValue(entity.getType().getType()));
-
-        if (isDropDownListType(entity)
-                && entity.getOptions() != null
-                && !entity.getOptions().isEmpty()) {
-            List<CustomFieldOptionDTO> options = entity.getOptions()
-                    .stream().map(CustomFieldMapper.INSTANCE::convertOptionEntityToOptionDto)
-                    .sorted(Comparator.comparing(CustomFieldOptionDTO::getDisplayText))
-                    .collect(Collectors.toList());
-            customField.setOptions(options);
-        }
-
-        return customField;
     }
 
     private boolean isDropDownListType(CustomFieldEntity customField) {

--- a/service/src/main/java/io/nuvalence/user/management/api/service/service/CustomFieldService.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/service/CustomFieldService.java
@@ -1,0 +1,221 @@
+package io.nuvalence.user.management.api.service.service;
+
+import io.nuvalence.user.management.api.service.config.exception.BusinessLogicException;
+import io.nuvalence.user.management.api.service.config.exception.ResourceNotFoundException;
+import io.nuvalence.user.management.api.service.entity.CustomFieldDataTypeEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldOptionEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldTypeEntity;
+import io.nuvalence.user.management.api.service.entity.UserCustomFieldEntity;
+import io.nuvalence.user.management.api.service.enums.CustomFieldType;
+import io.nuvalence.user.management.api.service.generated.models.CreateCustomFieldDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldOptionDTO;
+import io.nuvalence.user.management.api.service.generated.models.UpdateCustomFieldDTO;
+import io.nuvalence.user.management.api.service.mapper.CustomFieldMapper;
+import io.nuvalence.user.management.api.service.repository.CustomFieldDataTypeRepository;
+import io.nuvalence.user.management.api.service.repository.CustomFieldOptionRepository;
+import io.nuvalence.user.management.api.service.repository.CustomFieldRepository;
+import io.nuvalence.user.management.api.service.repository.CustomFieldTypeRepository;
+import io.nuvalence.user.management.api.service.repository.UserCustomFieldRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.transaction.Transactional;
+
+/**
+ * CustomField Service.
+ */
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class CustomFieldService {
+    private final UserCustomFieldRepository userCustomFieldRepository;
+    private final CustomFieldDataTypeRepository customFieldDataTypeRepository;
+    private final CustomFieldTypeRepository customFieldTypeRepository;
+    private final CustomFieldRepository customFieldRepository;
+    private final CustomFieldOptionRepository customFieldOptionRepository;
+
+    /**
+     * Gets all custom fields.
+     *
+     * @return A list of custom fields.
+     */
+    public ResponseEntity<List<CustomFieldDTO>> getCustomFields() {
+        List<CustomFieldEntity> allCustomFields = customFieldRepository.findAll();
+        if (allCustomFields.isEmpty()) {
+            throw new ResourceNotFoundException("No custom fields found.");
+        }
+
+        List<CustomFieldDTO> customFields = allCustomFields.stream()
+                .map(CustomFieldMapper.INSTANCE::convertEntityToDto)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(customFields);
+    }
+
+    /**
+     * Gets the options for a custom field.
+     *
+     * @param customFieldId the id of the custom field.
+     * @return a list of custom field options.
+     */
+    public ResponseEntity<List<CustomFieldOptionDTO>> getOptionsForCustomField(UUID customFieldId) {
+        Optional<CustomFieldEntity> customField = customFieldRepository.findById(customFieldId);
+        if (customField.isEmpty()) {
+            throw new ResourceNotFoundException("Custom field not found!");
+        }
+
+        if (isDropDownListType(customField.get())) {
+            throw new BusinessLogicException("The custom field is not a drop-down type.");
+        }
+
+        List<CustomFieldOptionDTO> options = customField.get().getOptions()
+                .stream().map(CustomFieldMapper.INSTANCE::convertOptionEntityToOptionDto)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(options);
+    }
+
+    /**
+     * Creates a new custom field.
+     *
+     * @param customField the custom field.
+     * @return a status code.
+     */
+    public ResponseEntity<Void> addCustomField(CreateCustomFieldDTO customField) {
+        Optional<CustomFieldEntity> checkName = customFieldRepository.findFirstByName(customField.getName());
+        if (checkName.isPresent()) {
+            throw new BusinessLogicException("A custom field with this name already exists.");
+        }
+
+        Optional<CustomFieldTypeEntity> customFieldType = customFieldTypeRepository
+                .findFirstByType(customField.getType().getValue());
+        Optional<CustomFieldDataTypeEntity> customFieldDataType = customFieldDataTypeRepository
+                .findFirstByType(customField.getDataType().getValue());
+
+        // these should always be found thanks to restricting by enum values, but check regardless
+        if (customFieldType.isEmpty()) {
+            throw new ResourceNotFoundException("Custom field type not found!");
+        }
+        if (customFieldDataType.isEmpty()) {
+            throw new ResourceNotFoundException("Custom field data type not found!");
+        }
+
+        CustomFieldEntity customFieldEntity = CustomFieldEntity.builder()
+                .name(customField.getName())
+                .type(customFieldType.get())
+                .dataType(customFieldDataType.get())
+                .displayText(customField.getDisplayText())
+                .build();
+        CustomFieldEntity savedCustomField = customFieldRepository.save(customFieldEntity);
+
+        if (isDropDownListType(customFieldEntity)
+                && customField.getOptions() != null
+                && !customField.getOptions().isEmpty()) {
+            List<CustomFieldOptionEntity> options = customField.getOptions()
+                    .stream().map(o -> CustomFieldMapper.INSTANCE.convertOptionDtoToOptionEntity(o, savedCustomField))
+                    .collect(Collectors.toList());
+            customFieldOptionRepository.saveAll(options);
+        }
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Updates an existing custom field.
+     *
+     * @param customFieldId the id of the custom field.
+     * @param customField the custom field.
+     * @return a status code.
+     */
+    public ResponseEntity<Void> updateCustomField(UUID customFieldId, UpdateCustomFieldDTO customField) {
+        Optional<CustomFieldEntity> foundCustomField = customFieldRepository.findById(customFieldId);
+        if (foundCustomField.isEmpty()) {
+            throw new ResourceNotFoundException("Custom field not found!");
+        }
+
+        foundCustomField.get().setName(customField.getName());
+        foundCustomField.get().setDisplayText(customField.getDisplayText());
+        CustomFieldEntity savedCustomField = customFieldRepository.save(foundCustomField.get());
+
+        customFieldOptionRepository.deleteAll(foundCustomField.get().getOptions());
+        if (isDropDownListType(foundCustomField.get())
+                && customField.getOptions() != null
+                && !customField.getOptions().isEmpty()) {
+            List<CustomFieldOptionEntity> options = customField.getOptions()
+                    .stream().map(o -> CustomFieldMapper.INSTANCE.convertOptionDtoToOptionEntity(o, savedCustomField))
+                    .collect(Collectors.toList());
+            customFieldOptionRepository.saveAll(options);
+        }
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Deletes an existing custom field.
+     *
+     * @param customFieldId the id of the custom field.
+     * @return a status code.
+     */
+    public ResponseEntity<Void> deleteCustomField(UUID customFieldId) {
+        Optional<CustomFieldEntity> foundCustomField = customFieldRepository.findById(customFieldId);
+        if (foundCustomField.isEmpty()) {
+            throw new ResourceNotFoundException("Custom field not found!");
+        }
+
+        List<UserCustomFieldEntity> userCustomFields = userCustomFieldRepository.findAllByCustomField(customFieldId);
+        userCustomFieldRepository.deleteAll(userCustomFields);
+        customFieldRepository.delete(foundCustomField.get());
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Updates the list of options for a custom field.
+     *
+     * @param customFieldId the id of the custom field.
+     * @param options a list of custom field options.
+     * @return a status code.
+     */
+    public ResponseEntity<Void> updateCustomFieldOptions(UUID customFieldId, List<CustomFieldOptionDTO> options) {
+        if (options == null || !options.isEmpty()) {
+            throw new BusinessLogicException("No options were passed in.");
+        }
+
+        Optional<CustomFieldEntity> customField = customFieldRepository.findById(customFieldId);
+
+        if (customField.isEmpty()) {
+            throw new ResourceNotFoundException("Custom field not found!");
+        }
+
+        if (isDropDownListType(customField.get())) {
+            throw new BusinessLogicException("The custom field is not a drop-down type.");
+        }
+
+        List<CustomFieldOptionEntity> existingCustomFieldOptions = customFieldOptionRepository
+                .findByCustomField(customFieldId);
+
+        List<CustomFieldOptionEntity> optionEntities = options
+                .stream().map(o -> CustomFieldMapper.INSTANCE.convertOptionDtoToOptionEntity(o, customField.get()))
+                .collect(Collectors.toList());
+
+        customFieldOptionRepository.deleteAll(existingCustomFieldOptions);
+        customFieldOptionRepository.saveAll(optionEntities);
+
+        return ResponseEntity.ok().build();
+    }
+
+    private boolean isDropDownListType(CustomFieldEntity customField) {
+        return  CustomFieldType.fromText(customField.getType().getType()) != CustomFieldType.DROP_DOWN_LIST;
+    }
+}

--- a/service/src/main/java/io/nuvalence/user/management/api/service/service/UserService.java
+++ b/service/src/main/java/io/nuvalence/user/management/api/service/service/UserService.java
@@ -1,18 +1,25 @@
 package io.nuvalence.user.management.api.service.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.nuvalence.user.management.api.service.cerbos.CerbosClient;
 import io.nuvalence.user.management.api.service.config.exception.BusinessLogicException;
 import io.nuvalence.user.management.api.service.config.exception.ResourceNotFoundException;
+import io.nuvalence.user.management.api.service.entity.CustomFieldEntity;
 import io.nuvalence.user.management.api.service.entity.RoleEntity;
+import io.nuvalence.user.management.api.service.entity.UserCustomFieldEntity;
 import io.nuvalence.user.management.api.service.entity.UserEntity;
 import io.nuvalence.user.management.api.service.entity.UserRoleEntity;
+import io.nuvalence.user.management.api.service.enums.CustomFieldDataType;
+import io.nuvalence.user.management.api.service.generated.models.CreateOrUpdateUserCustomFieldDTO;
 import io.nuvalence.user.management.api.service.generated.models.RoleDTO;
 import io.nuvalence.user.management.api.service.generated.models.UserCreationRequest;
 import io.nuvalence.user.management.api.service.generated.models.UserDTO;
 import io.nuvalence.user.management.api.service.generated.models.UserRoleDTO;
 import io.nuvalence.user.management.api.service.mapper.MapperUtils;
 import io.nuvalence.user.management.api.service.mapper.UserEntityMapper;
+import io.nuvalence.user.management.api.service.repository.CustomFieldRepository;
 import io.nuvalence.user.management.api.service.repository.RoleRepository;
+import io.nuvalence.user.management.api.service.repository.UserCustomFieldRepository;
 import io.nuvalence.user.management.api.service.repository.UserRepository;
 import io.nuvalence.user.management.api.service.repository.UserRoleRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +30,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
@@ -39,10 +47,13 @@ import javax.transaction.Transactional;
 @Transactional
 @RequiredArgsConstructor
 @Slf4j
+@SuppressWarnings("checkstyle:ClassFanOutComplexity")
 public class UserService {
 
     private final UserRepository userRepository;
     private final UserRoleRepository userRoleRepository;
+    private final CustomFieldRepository customFieldRepository;
+    private final UserCustomFieldRepository userCustomFieldRepository;
     private final RoleRepository roleRepository;
     private final CerbosClient client;
 
@@ -70,22 +81,57 @@ public class UserService {
         UserEntity savedUser = userRepository.save(userEntity);
 
         // If roles are provided we want to initialize them here.
-        if (!user.getInitialRoles().isEmpty()) {
-            List<RoleEntity> roleEntities = user.getInitialRoles().stream().map(role -> {
-                RoleEntity roleEntity = roleRepository.getById(role.getId());
-                if (roleEntity == null) {
-                    throw new BusinessLogicException(String.format("No role found for %s.", role.getRoleName()));
-                }
-                return roleEntity;
-            }).collect(Collectors.toList());
+        if (user.getInitialRoles() != null && !user.getInitialRoles().isEmpty()) {
+            List<UserRoleEntity> userRoleEntities = roleRepository.findAllById(user.getInitialRoles()
+                    .stream().map(RoleDTO::getId).collect(Collectors.toList()))
+                    .stream().map(r -> {
+                        UserRoleEntity userRoleEntity = new UserRoleEntity();
+                        userRoleEntity.setUser(savedUser);
+                        userRoleEntity.setRole(r);
+                        return userRoleEntity;
+                    }).collect(Collectors.toList());
+            Optional<RoleDTO> notFoundRole = user.getInitialRoles()
+                    .stream().filter(r -> userRoleEntities.stream().noneMatch(re -> re.getRole().getId() == r.getId()))
+                    .findFirst();
+            if (notFoundRole.isPresent()) {
+                throw new BusinessLogicException(
+                        String.format("No role found for %s.", notFoundRole.get().getRoleName())
+                );
+            }
+            userRoleRepository.saveAll(userRoleEntities);
+        }
 
-
-            roleEntities.forEach(role -> {
-                UserRoleEntity userRoleEntity = new UserRoleEntity();
-                userRoleEntity.setUser(savedUser);
-                userRoleEntity.setRole(role);
-                userRoleRepository.save(userRoleEntity);
-            });
+        if (user.getCustomFields() != null && !user.getCustomFields().isEmpty()) {
+            Map<UUID, CreateOrUpdateUserCustomFieldDTO> userCustomFields = user.getCustomFields()
+                    .stream().collect(Collectors.toMap(CreateOrUpdateUserCustomFieldDTO::getCustomFieldId, c -> c));
+            List<UserCustomFieldEntity> userCustomFieldEntities = customFieldRepository
+                    .findAllById(user.getCustomFields()
+                    .stream().map(CreateOrUpdateUserCustomFieldDTO::getCustomFieldId).collect(Collectors.toList()))
+                    .stream().map(c -> {
+                        UserCustomFieldEntity userCustomField = UserCustomFieldEntity.builder()
+                                .user(savedUser)
+                                .customField(c)
+                                .build();
+                        try {
+                            setUserCustomFieldValueFromCustomFieldDto(c, userCustomField,
+                                    userCustomFields.get(c.getId()));
+                        } catch (Exception e) {
+                            log.error("Exception occurred at UserService.createUser: {}", e.getMessage());
+                        }
+                        return userCustomField;
+                    }).collect(Collectors.toList());
+            Optional<CreateOrUpdateUserCustomFieldDTO> notFoundCustomField = user.getCustomFields()
+                    .stream().filter(c -> userCustomFieldEntities.stream()
+                            .noneMatch(cf -> cf.getCustomField().getId() == c.getCustomFieldId())
+                    )
+                    .findFirst();
+            if (notFoundCustomField.isPresent()) {
+                throw new BusinessLogicException(
+                        String.format("No custom field found with id: %s.",
+                                notFoundCustomField.get().getCustomFieldId())
+                );
+            }
+            userCustomFieldRepository.saveAll(userCustomFieldEntities);
         }
 
         return ResponseEntity.status(200).build();
@@ -99,11 +145,13 @@ public class UserService {
      */
     public ResponseEntity<Void> deleteUser(UUID userId) {
         List<UserRoleEntity> userRoleEntities = userRoleRepository.findAllByUserId(userId);
+        List<UserCustomFieldEntity> userCustomFieldEntities = userCustomFieldRepository.findAllByUserId(userId);
         Optional<UserEntity> userEntity = userRepository.findById(userId);
 
         if (userEntity.isEmpty()) {
             throw new ResourceNotFoundException("User not found.");
         }
+        userCustomFieldRepository.deleteAll(userCustomFieldEntities);
         userRoleRepository.deleteAll(userRoleEntities);
         userRepository.delete(userEntity.get());
 
@@ -221,6 +269,7 @@ public class UserService {
 
         UserDTO user = UserEntityMapper.INSTANCE.convertUserEntityToUserModel(userEntity.get());
         user.setAssignedRoles(MapperUtils.mapUserEntityToRoleList(userEntity.get(), rolePermissionMappings));
+        user.setCustomFields(MapperUtils.mapUserEntityToCustomFieldDtoList(userEntity.get()));
 
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(user);
     }
@@ -244,5 +293,67 @@ public class UserService {
         UserDTO userDto = UserEntityMapper.INSTANCE.convertUserEntityToUserModel(user.get());
         userDto.setAssignedRoles(MapperUtils.mapUserEntityToRoleList(user.get(), rolePermissionMappings));
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(userDto);
+    }
+
+    /**
+     * Updates (or creates if it doesn't already exist) a custom field with the provided value.
+     *
+     * @param userId the id of the user.
+     * @param userCustomField is a DTO of the user custom field to be updated/created.
+     * @return a status code
+     * @throws Exception if the provided json could not be serialized
+     */
+    public ResponseEntity<Void> updateCustomField(UUID userId, CreateOrUpdateUserCustomFieldDTO userCustomField)
+            throws Exception {
+        Optional<UserEntity> user = userRepository.findById(userId);
+        if (user.isEmpty()) {
+            throw new ResourceNotFoundException("User not found!");
+        }
+
+        Optional<CustomFieldEntity> customField = customFieldRepository.findById(userCustomField.getCustomFieldId());
+        if (customField.isEmpty()) {
+            throw new ResourceNotFoundException("Custom field not found!");
+        }
+
+        Optional<UserCustomFieldEntity> userCustomFieldEntity = userCustomFieldRepository
+                .findFirstByUserAndCustomField(userId, userCustomField.getCustomFieldId());
+
+        if (userCustomFieldEntity.isEmpty()) {
+            userCustomFieldEntity = Optional.of(UserCustomFieldEntity.builder()
+                            .user(user.get())
+                            .customField(customField.get())
+                            .build());
+        }
+
+        setUserCustomFieldValueFromCustomFieldDto(customField.get(), userCustomFieldEntity.get(), userCustomField);
+        userCustomFieldRepository.save(userCustomFieldEntity.get());
+        return ResponseEntity.ok().build();
+    }
+
+    private void setUserCustomFieldValueFromCustomFieldDto(CustomFieldEntity customField,
+                                                           UserCustomFieldEntity userCustomFieldEntity,
+                                                           CreateOrUpdateUserCustomFieldDTO userCustomField)
+            throws Exception {
+        switch (CustomFieldDataType.fromText(customField.getDataType().getType())) {
+            case INT:
+                userCustomFieldEntity.setCustomFieldValueInt((Integer)userCustomField.getValue());
+                break;
+            case JSON:
+                if (userCustomField.getValue() != null) {
+                    userCustomFieldEntity.setCustomFieldValueJson(
+                            new ObjectMapper().writeValueAsString(userCustomField.getValue())
+                    );
+                } else {
+                    userCustomFieldEntity.setCustomFieldValueJson(null);
+                }
+                break;
+            case DATETIME:
+                userCustomFieldEntity.setCustomFieldValueDateTime((OffsetDateTime)userCustomField.getValue());
+                break;
+            default:
+            case STRING:
+                userCustomFieldEntity.setCustomFieldValueString((String)userCustomField.getValue());
+                break;
+        }
     }
 }

--- a/service/src/main/resources/application-test.yml
+++ b/service/src/main/resources/application-test.yml
@@ -1,14 +1,14 @@
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;INIT=CREATE TYPE IF NOT EXISTS "JSONB" AS text;
     username: sa
     password: sa
   liquibase:
     enabled: true
     change-log: classpath:db/liquibase-changelog.xml
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;INIT=CREATE TYPE IF NOT EXISTS "JSONB" AS text;
     user: sa
     password: sa
   jpa:
@@ -19,7 +19,7 @@ spring:
       path: /h2-console
     liquibase:
       driver-class-name: org.h2.Driver
-      url: jdbc:h2:mem:db;NON_KEYWORDS=USER;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+      url: jdbc:h2:mem:db;NON_KEYWORDS=USER;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;INIT=CREATE TYPE IF NOT EXISTS "JSONB" AS text;
       user: sa
       password: sa
 

--- a/service/src/main/resources/db/Initial-Tables.xml
+++ b/service/src/main/resources/db/Initial-Tables.xml
@@ -300,7 +300,8 @@
         <addUniqueConstraint tableName="user_custom_field" columnNames="user_id, custom_field_id" constraintName="Unique_CustomField_To_User" />
         <sql>
             INSERT INTO custom_field_type (id, type)
-            VALUES ('a80a48b5-2995-4c54-9bd5-ebc258fab4ba', 'drop_down_list');
+            VALUES ('a80a48b5-2995-4c54-9bd5-ebc258fab4ba', 'drop_down_list'),
+                   ('5fc38fee-e8f5-11ec-8fea-0242ac120002', 'text_field');
         </sql>
         <sql>
             INSERT INTO custom_field_data_type (id, type)

--- a/service/src/main/resources/db/Initial-Tables.xml
+++ b/service/src/main/resources/db/Initial-Tables.xml
@@ -197,4 +197,117 @@
                     ('edcb5992-2788-4042-b125-38b145c1e830', '551e4105-0a7e-40a0-a9b6-7dc3a504d561', 'c95afee7-2bc4-4c12-acdd-344b5432520e');
         </sql>
     </changeSet>
+    <changeSet id="custom-fields-introduction" author="open-source-initial-author">
+        <createTable tableName="custom_field_type">
+            <column name="id" type="uuid">
+                <constraints primaryKey="true"
+                             primaryKeyName="pk_custom_field_type"
+                             nullable="false"/>
+            </column>
+            <column name="type" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createIndex tableName="custom_field_type" indexName="IX_custom_field_type_type">
+            <column name="type" />
+        </createIndex>
+        <createTable tableName="custom_field_data_type">
+            <column name="id" type="uuid">
+                <constraints primaryKey="true"
+                             primaryKeyName="pk_custom_field_data_type"
+                             nullable="false"/>
+            </column>
+            <column name="type" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createIndex tableName="custom_field_data_type" indexName="IX_custom_field_data_type_type">
+            <column name="type" />
+        </createIndex>
+        <createTable tableName="custom_field">
+            <column name="id" type="uuid">
+                <constraints primaryKey="true"
+                             primaryKeyName="pk_custom_field"
+                             nullable="false"/>
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false" unique="true" />
+            </column>
+            <column name="custom_field_type_id" type="uuid">
+                <constraints foreignKeyName="fk_custom_field_custom_field_type"
+                             references="custom_field_type(id)"
+                             nullable="false"/>
+            </column>
+            <column name="custom_field_data_type_id" type="uuid">
+                <constraints foreignKeyName="fk_custom_field_data_type"
+                             references="custom_field_data_type(id)"
+                             nullable="false"/>
+            </column>
+            <column name="display_text" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createIndex tableName="custom_field" indexName="IX_custom_field_name">
+            <column name="name" />
+        </createIndex>
+        <createTable tableName="custom_field_option">
+            <column name="id" type="uuid">
+                <constraints primaryKey="true"
+                             primaryKeyName="pk_custom_field_option"
+                             nullable="false"/>
+            </column>
+            <column name="custom_field_id" type="uuid">
+                <constraints foreignKeyName="fk_custom_field_option_custom_field"
+                             references="custom_field(id)"
+                             nullable="false"/>
+            </column>
+            <column name="option_value" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="display_text" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createTable tableName="user_custom_field">
+            <column name="id" type="uuid">
+                <constraints primaryKey="true"
+                             primaryKeyName="pk_user_custom_field"
+                             nullable="false"/>
+            </column>
+            <column name="user_id" type="uuid">
+                <constraints foreignKeyName="fk_user_custom_field_user"
+                             references="user_table(id)"
+                             nullable="false"/>
+            </column>
+            <column name="custom_field_id" type="uuid">
+                <constraints foreignKeyName="fk_user_custom_field_custom_field"
+                             references="custom_field(id)"
+                             nullable="false"/>
+            </column>
+            <column name="custom_field_value_string" type="varchar(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="custom_field_value_int" type="int">
+                <constraints nullable="true"/>
+            </column>
+            <column name="custom_field_value_json" type="JSONB">
+                <constraints nullable="true"/>
+            </column>
+            <column name="custom_field_value_datetime" type="datetime">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="user_custom_field" columnNames="user_id, custom_field_id" constraintName="Unique_CustomField_To_User" />
+        <sql>
+            INSERT INTO custom_field_type (id, type)
+            VALUES ('a80a48b5-2995-4c54-9bd5-ebc258fab4ba', 'drop_down_list');
+        </sql>
+        <sql>
+            INSERT INTO custom_field_data_type (id, type)
+            VALUES ('3e724ddf-4d09-452b-ae98-a8e3a76af19c', 'string'),
+                   ('7c6e4de3-5461-4a38-bdf8-2f853c50e3a3', 'int'),
+                   ('69af3a92-b6d6-4b6a-90e5-51304cba887c', 'json'),
+                   ('5d01d9e3-f8a8-42e3-877c-b743bff79e7f', 'datetime');
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/service/src/test/java/io/nuvalence/user/management/api/service/controller/CustomFieldsApiDelegateImplTest.java
+++ b/service/src/test/java/io/nuvalence/user/management/api/service/controller/CustomFieldsApiDelegateImplTest.java
@@ -1,0 +1,177 @@
+package io.nuvalence.user.management.api.service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nuvalence.user.management.api.service.generated.models.CreateCustomFieldDTO;
+import io.nuvalence.user.management.api.service.generated.models.CreateOrUpdateCustomFieldOptionDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldOptionDTO;
+import io.nuvalence.user.management.api.service.generated.models.UpdateCustomFieldDTO;
+import io.nuvalence.user.management.api.service.service.CustomFieldService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class CustomFieldsApiDelegateImplTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CustomFieldService customFieldService;
+
+    @Test
+    public void getAllCustomFields() throws Exception {
+        List<CustomFieldDTO> fields = List.of(getMockCustomFieldDto());
+        ResponseEntity<List<CustomFieldDTO>> res = ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(fields);
+        when(customFieldService.getAllCustomFields()).thenReturn(res);
+
+        mockMvc.perform(
+                get("/api/v2/custom-fields"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value(fields.get(0).getName()));
+    }
+
+    @Test
+    public void addCustomField() throws Exception {
+        ResponseEntity<Void> res = ResponseEntity.ok().build();
+        CreateCustomFieldDTO customField = getMockCreateCustomFieldDto();
+        when(customFieldService.addCustomField(getMockCreateCustomFieldDto()))
+                .thenReturn(res);
+        final String postBody = new ObjectMapper().writeValueAsString(customField);
+
+        mockMvc.perform(
+                post("/api/v2/custom-fields")
+                        .content(postBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getCustomFieldById() throws Exception {
+        CustomFieldDTO customField = getMockCustomFieldDto();
+        ResponseEntity<CustomFieldDTO> res = ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(customField);
+        when(customFieldService.getCustomFieldById(any())).thenReturn(res);
+
+        mockMvc.perform(
+                get("/api/v2/custom-fields/" + customField.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(customField.getName()));
+    }
+
+    @Test
+    public void updateCustomField() throws Exception {
+        UpdateCustomFieldDTO customField = getMockUpdateCustomFieldDto();
+        ResponseEntity<Void> res = ResponseEntity.ok().build();
+        when(customFieldService.updateCustomField(any(), any())).thenReturn(res);
+        final String putBody = new ObjectMapper().writeValueAsString(customField);
+
+        mockMvc.perform(
+                put("/api/v2/custom-fields/" + UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(putBody))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void deleteCustomField() throws Exception {
+        ResponseEntity<Void> res = ResponseEntity.ok().build();
+        when(customFieldService.deleteCustomField(any())).thenReturn(res);
+
+        mockMvc.perform(
+                delete("/api/v2/custom-fields/" + UUID.randomUUID()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getOptionsForCustomField() throws Exception {
+        List<CustomFieldOptionDTO> options = List.of(getMockCustomFieldOptionDto());
+        ResponseEntity<List<CustomFieldOptionDTO>> res = ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(options);
+        when(customFieldService.getOptionsForCustomField(any())).thenReturn(res);
+
+        mockMvc.perform(
+                get("/api/v2/custom-fields/" + UUID.randomUUID() + "/options"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].optionValue").value(options.get(0).getOptionValue()));
+    }
+
+    @Test
+    public void updateCustomFieldOptions() throws Exception {
+        List<CreateOrUpdateCustomFieldOptionDTO> options = List.of(getMockCreateOrUpdateCustomFieldOptionDto());
+        ResponseEntity<Void> res = ResponseEntity.ok().build();
+        final String putBody = new ObjectMapper().writeValueAsString(options);
+        when(customFieldService.updateCustomFieldOptions(any(), any())).thenReturn(res);
+
+        mockMvc.perform(
+                put("/api/v2/custom-fields/" + UUID.randomUUID() + "/options")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(putBody))
+                .andExpect(status().isOk());
+    }
+
+    private CustomFieldDTO getMockCustomFieldDto() {
+        CustomFieldDTO customField = new CustomFieldDTO();
+        customField.setId(UUID.randomUUID());
+        customField.setName("TEST_FIELD_1");
+        customField.setDisplayText("Test Field 1");
+        customField.setType(CustomFieldDTO.TypeEnum.TEXT_FIELD);
+        customField.setDataType(CustomFieldDTO.DataTypeEnum.STRING);
+        return customField;
+    }
+
+    private CreateCustomFieldDTO getMockCreateCustomFieldDto() {
+        CreateCustomFieldDTO customField = new CreateCustomFieldDTO();
+        customField.setName("TEST_FIELD_1");
+        customField.setDisplayText("Test Field 1");
+        customField.setDataType(CreateCustomFieldDTO.DataTypeEnum.STRING);
+        customField.setType(CreateCustomFieldDTO.TypeEnum.TEXT_FIELD);
+        return customField;
+    }
+
+    private UpdateCustomFieldDTO getMockUpdateCustomFieldDto() {
+        UpdateCustomFieldDTO customField = new UpdateCustomFieldDTO();
+        customField.setName("TEST_FIELD_1");
+        customField.setDisplayText("Test Field 1");
+        return customField;
+    }
+
+    private CustomFieldOptionDTO getMockCustomFieldOptionDto() {
+        CustomFieldOptionDTO option = new CustomFieldOptionDTO();
+        option.setId(UUID.randomUUID());
+        option.setOptionValue("OPTION_1");
+        option.setDisplayText("Option 1");
+        return option;
+    }
+
+    private CreateOrUpdateCustomFieldOptionDTO getMockCreateOrUpdateCustomFieldOptionDto() {
+        CreateOrUpdateCustomFieldOptionDTO option = new CreateOrUpdateCustomFieldOptionDTO();
+        option.setOptionValue("OPTION_1");
+        option.setDisplayText("Option 1");
+        return option;
+    }
+}

--- a/service/src/test/java/io/nuvalence/user/management/api/service/controller/UserApiDelegateImplTest.java
+++ b/service/src/test/java/io/nuvalence/user/management/api/service/controller/UserApiDelegateImplTest.java
@@ -3,6 +3,7 @@ package io.nuvalence.user.management.api.service.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.nuvalence.user.management.api.service.entity.RoleEntity;
 import io.nuvalence.user.management.api.service.entity.UserEntity;
+import io.nuvalence.user.management.api.service.generated.models.CreateOrUpdateUserCustomFieldDTO;
 import io.nuvalence.user.management.api.service.generated.models.RoleDTO;
 import io.nuvalence.user.management.api.service.generated.models.UserCreationRequest;
 import io.nuvalence.user.management.api.service.generated.models.UserDTO;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -160,6 +162,20 @@ public class UserApiDelegateImplTest {
         ).andExpect(status().isOk());
     }
 
+    @Test
+    public void updateUserCustomFieldValue() throws Exception {
+        CreateOrUpdateUserCustomFieldDTO customField = createMockUserCustomFieldDto();
+        ResponseEntity<Void> res = ResponseEntity.ok().build();
+        when(userService.updateCustomField(any(), any())).thenReturn(res);
+        final String putBody = new ObjectMapper().writeValueAsString(customField);
+
+        mockMvc.perform(
+                put("/api/v2/user/" + UUID.randomUUID() + "/custom-field")
+                        .content(putBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+    }
+
     private UserDTO createUserModel() {
         UserDTO user = new UserDTO();
         user.setId(UUID.randomUUID());
@@ -202,6 +218,13 @@ public class UserApiDelegateImplTest {
         userRole.setRoleId(role.getId());
         userRole.setUserId(user.getId());
         return userRole;
+    }
+
+    private CreateOrUpdateUserCustomFieldDTO createMockUserCustomFieldDto() {
+        CreateOrUpdateUserCustomFieldDTO customField = new CreateOrUpdateUserCustomFieldDTO();
+        customField.setCustomFieldId(UUID.randomUUID());
+        customField.setValue("OPTION_1");
+        return customField;
     }
 
 }

--- a/service/src/test/java/io/nuvalence/user/management/api/service/mapper/CustomFieldMapperTest.java
+++ b/service/src/test/java/io/nuvalence/user/management/api/service/mapper/CustomFieldMapperTest.java
@@ -1,0 +1,74 @@
+package io.nuvalence.user.management.api.service.mapper;
+
+import io.nuvalence.user.management.api.service.entity.CustomFieldDataTypeEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldOptionEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldTypeEntity;
+import io.nuvalence.user.management.api.service.generated.models.CreateOrUpdateCustomFieldOptionDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class CustomFieldMapperTest {
+
+    @Test
+    public void shouldMapCustomFieldEntityToCustomFieldDto() {
+        CustomFieldEntity customFieldEntity = getCustomFieldEntity();
+        CustomFieldDTO customFieldModel = CustomFieldMapper.INSTANCE.convertEntityToDto(customFieldEntity);
+        assertEquals(customFieldEntity.getId(), customFieldModel.getId());
+        assertEquals(customFieldEntity.getName(), customFieldModel.getName());
+        assertEquals(customFieldEntity.getDisplayText(), customFieldModel.getDisplayText());
+        assertEquals(customFieldEntity.getType().getType(), customFieldModel.getType().getValue());
+        assertEquals(customFieldEntity.getDataType().getType(), customFieldModel.getDataType().getValue());
+        assertEquals(customFieldEntity.getOptions().get(0).getDisplayText(),
+                customFieldModel.getOptions().get(0).getDisplayText());
+        assertEquals(customFieldEntity.getOptions().get(0).getOptionValue(),
+                customFieldModel.getOptions().get(0).getOptionValue());
+    }
+
+    @Test
+    public void shouldMapCreateOrUpdateCustomFieldOptionDtoToCustomFieldOptionEntity() {
+        CreateOrUpdateCustomFieldOptionDTO option = new CreateOrUpdateCustomFieldOptionDTO();
+        option.setOptionValue("VALUE_1");
+        option.setDisplayText("Value 1");
+        CustomFieldEntity customFieldEntity = getCustomFieldEntity();
+
+        CustomFieldOptionEntity optionEntity = CustomFieldMapper.INSTANCE
+                .convertOptionDtoToOptionEntity(option, customFieldEntity);
+        assertEquals(optionEntity.getDisplayText(), option.getDisplayText());
+        assertEquals(optionEntity.getOptionValue(), option.getOptionValue());
+        assertEquals(optionEntity.getCustomField().getId(), customFieldEntity.getId());
+    }
+
+    private CustomFieldEntity getCustomFieldEntity() {
+        CustomFieldEntity customFieldEntity = new CustomFieldEntity();
+        customFieldEntity.setId(UUID.randomUUID());
+        customFieldEntity.setName("CUSTOM_FIELD_1");
+
+        CustomFieldTypeEntity customFieldTypeEntity = new CustomFieldTypeEntity();
+        customFieldTypeEntity.setId(UUID.fromString("a80a48b5-2995-4c54-9bd5-ebc258fab4ba"));
+        customFieldTypeEntity.setType("drop_down_list");
+        customFieldEntity.setDisplayText("Custom Field 1");
+        customFieldEntity.setType(customFieldTypeEntity);
+
+        CustomFieldDataTypeEntity customFieldDataTypeEntity = new CustomFieldDataTypeEntity();
+        customFieldDataTypeEntity.setId(UUID.fromString("3e724ddf-4d09-452b-ae98-a8e3a76af19c"));
+        customFieldDataTypeEntity.setType("string");
+
+        customFieldEntity.setDataType(customFieldDataTypeEntity);
+        CustomFieldOptionEntity option = new CustomFieldOptionEntity();
+        option.setId(UUID.randomUUID());
+        option.setOptionValue("VALUE_1");
+
+        customFieldEntity.setOptions(List.of(option));
+
+        return customFieldEntity;
+    }
+}

--- a/service/src/test/java/io/nuvalence/user/management/api/service/mapper/MapperUtilsTest.java
+++ b/service/src/test/java/io/nuvalence/user/management/api/service/mapper/MapperUtilsTest.java
@@ -1,10 +1,16 @@
 package io.nuvalence.user.management.api.service.mapper;
 
 import io.nuvalence.user.management.api.service.entity.ApplicationPreferenceEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldDataTypeEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldOptionEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldTypeEntity;
 import io.nuvalence.user.management.api.service.entity.LanguageEntity;
 import io.nuvalence.user.management.api.service.entity.RoleEntity;
+import io.nuvalence.user.management.api.service.entity.UserCustomFieldEntity;
 import io.nuvalence.user.management.api.service.entity.UserPreferenceEntity;
 import io.nuvalence.user.management.api.service.generated.models.RoleDTO;
+import io.nuvalence.user.management.api.service.generated.models.UserCustomFieldDTO;
 import io.nuvalence.user.management.api.service.generated.models.UserPreferenceDTO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,5 +109,45 @@ public class MapperUtilsTest {
         UserPreferenceDTO result = MapperUtils.overlapPreferences(preference, applicationPreferences);
 
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void shouldMapUserCustomFieldEntityToDto() {
+        CustomFieldOptionEntity option = new CustomFieldOptionEntity();
+        option.setId(UUID.randomUUID());
+        option.setOptionValue("VALUE_1");
+        option.setDisplayText("Value 1");
+
+        CustomFieldEntity customFieldEntity = new CustomFieldEntity();
+        customFieldEntity.setId(UUID.randomUUID());
+        customFieldEntity.setName("CUSTOM_FIELD_1");
+        CustomFieldTypeEntity customFieldTypeEntity = new CustomFieldTypeEntity();
+        customFieldTypeEntity.setId(UUID.fromString("a80a48b5-2995-4c54-9bd5-ebc258fab4ba"));
+        customFieldTypeEntity.setType("drop_down_list");
+        customFieldEntity.setType(customFieldTypeEntity);
+        CustomFieldDataTypeEntity customFieldDataTypeEntity = new CustomFieldDataTypeEntity();
+        customFieldDataTypeEntity.setId(UUID.fromString("3e724ddf-4d09-452b-ae98-a8e3a76af19c"));
+        customFieldDataTypeEntity.setType("string");
+        customFieldEntity.setDataType(customFieldDataTypeEntity);
+        customFieldEntity.setDisplayText("Custom Field 1");
+        customFieldEntity.setOptions(List.of(option));
+
+        UserCustomFieldEntity userCustomFieldEntity = new UserCustomFieldEntity();
+        userCustomFieldEntity.setId(UUID.randomUUID());
+        userCustomFieldEntity.setCustomField(customFieldEntity);
+        userCustomFieldEntity.setCustomFieldValueString("TEST1");
+
+        UserCustomFieldDTO userCustomFieldModel = MapperUtils.mapUserCustomFieldEntityToDto(userCustomFieldEntity);
+        assertEquals(userCustomFieldModel.getId(), userCustomFieldEntity.getId());
+        assertEquals(userCustomFieldModel.getCustomFieldId(), userCustomFieldEntity.getCustomField().getId());
+        assertEquals(userCustomFieldModel.getType().getValue(),
+                userCustomFieldEntity.getCustomField().getType().getType());
+        assertEquals(userCustomFieldModel.getDataType().getValue(),
+                userCustomFieldEntity.getCustomField().getDataType().getType());
+        assertEquals(userCustomFieldModel.getName(), userCustomFieldEntity.getCustomField().getName());
+        assertEquals(userCustomFieldModel.getDisplayText(), userCustomFieldEntity.getCustomField().getDisplayText());
+        assertEquals(userCustomFieldModel.getValue(), "TEST1");
+        assertEquals(userCustomFieldModel.getOptions().get(0).getOptionValue(),
+                userCustomFieldEntity.getCustomField().getOptions().get(0).getOptionValue());
     }
 }

--- a/service/src/test/java/io/nuvalence/user/management/api/service/service/CustomFieldServiceTest.java
+++ b/service/src/test/java/io/nuvalence/user/management/api/service/service/CustomFieldServiceTest.java
@@ -1,0 +1,532 @@
+package io.nuvalence.user.management.api.service.service;
+
+import io.nuvalence.user.management.api.service.config.exception.BusinessLogicException;
+import io.nuvalence.user.management.api.service.config.exception.ResourceNotFoundException;
+import io.nuvalence.user.management.api.service.entity.CustomFieldDataTypeEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldOptionEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldTypeEntity;
+import io.nuvalence.user.management.api.service.entity.UserCustomFieldEntity;
+import io.nuvalence.user.management.api.service.generated.models.CreateCustomFieldDTO;
+import io.nuvalence.user.management.api.service.generated.models.CreateOrUpdateCustomFieldOptionDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldDTO;
+import io.nuvalence.user.management.api.service.generated.models.CustomFieldOptionDTO;
+import io.nuvalence.user.management.api.service.generated.models.UpdateCustomFieldDTO;
+import io.nuvalence.user.management.api.service.repository.CustomFieldDataTypeRepository;
+import io.nuvalence.user.management.api.service.repository.CustomFieldOptionRepository;
+import io.nuvalence.user.management.api.service.repository.CustomFieldRepository;
+import io.nuvalence.user.management.api.service.repository.CustomFieldTypeRepository;
+import io.nuvalence.user.management.api.service.repository.UserCustomFieldRepository;
+import org.assertj.core.util.IterableUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CustomFieldServiceTest {
+    @Mock
+    private UserCustomFieldRepository userCustomFieldRepository;
+
+    @Mock
+    private CustomFieldDataTypeRepository customFieldDataTypeRepository;
+
+    @Mock
+    private CustomFieldTypeRepository customFieldTypeRepository;
+
+    @Mock
+    private CustomFieldRepository customFieldRepository;
+
+    @Mock
+    private CustomFieldOptionRepository customFieldOptionRepository;
+
+    @InjectMocks
+    private CustomFieldService customFieldService;
+
+    @Captor
+    private ArgumentCaptor<CustomFieldEntity> customFieldCaptor;
+
+    @Captor
+    private ArgumentCaptor<Iterable<CustomFieldOptionEntity>> customFieldOptionListCaptor;
+
+    @Captor
+    private ArgumentCaptor<Iterable<UserCustomFieldEntity>> userCustomFieldListCaptor;
+
+    @Test
+    public void getAllCustomFields_succeeds_if_valid() {
+        List<CustomFieldEntity> customFields = List.of(getCustomFieldEntity());
+        when(customFieldRepository.findAll(Sort.by(Sort.Direction.ASC, "displayText")))
+                .thenReturn(customFields);
+
+        ResponseEntity<List<CustomFieldDTO>> res = customFieldService.getAllCustomFields();
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+
+        assertEquals(Objects.requireNonNull(res.getBody()).size(), customFields.size());
+        assertEquals(res.getBody().get(0).getName(), customFields.get(0).getName());
+    }
+
+    @Test
+    public void getAllCustomField_fails_if_empty_list() {
+        when(customFieldRepository.findAll(Sort.by(Sort.Direction.ASC, "displayText")))
+                .thenReturn(Collections.emptyList());
+
+        Exception exception = assertThrows(ResourceNotFoundException.class, () ->
+                customFieldService.getAllCustomFields());
+        assertEquals(exception.getMessage(), "No custom fields found.");
+    }
+
+    @Test
+    public void getCustomFieldById_succeeds_if_field_exists() {
+        CustomFieldEntity customField = getCustomFieldEntity();
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customField));
+
+        ResponseEntity<CustomFieldDTO> res = customFieldService.getCustomFieldById(UUID.randomUUID());
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        assertEquals(Objects.requireNonNull(res.getBody()).getName(), customField.getName());
+    }
+
+    @Test
+    public void getCustomFieldById_fails_if_field_does_not_exist() {
+        when(customFieldRepository.findById(any())).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(ResourceNotFoundException.class, () ->
+                customFieldService.getCustomFieldById(UUID.randomUUID()));
+        assertEquals(exception.getMessage(), "Custom field not found!");
+    }
+
+    @Test
+    public void getOptionsForCustomField_succeeds_if_field_is_dropDown() {
+        CustomFieldEntity customField = getCustomFieldEntity();
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customField));
+
+        ResponseEntity<List<CustomFieldOptionDTO>> res = customFieldService.getOptionsForCustomField(UUID.randomUUID());
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        assertEquals(Objects.requireNonNull(res.getBody()).size(), customField.getOptions().size());
+        assertEquals(res.getBody().get(0).getOptionValue(), customField.getOptions().get(0).getOptionValue());
+    }
+
+    @Test
+    public void getOptionsForCustomField_fails_if_field_does_not_exist() {
+        when(customFieldRepository.findById(any())).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(ResourceNotFoundException.class, () ->
+                customFieldService.getOptionsForCustomField(UUID.randomUUID()));
+        assertEquals(exception.getMessage(), "Custom field not found!");
+    }
+
+    @Test
+    public void getOptionsForCustomField_fails_if_field_is_not_dropdown() {
+        CustomFieldEntity customField = getCustomFieldEntity();
+        customField.setType(getTextFieldTypeEntity());
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customField));
+
+        Exception exception = assertThrows(BusinessLogicException.class, () ->
+                customFieldService.getOptionsForCustomField(UUID.randomUUID())
+        );
+        assertEquals(exception.getMessage(), "The custom field is not a drop-down type.");
+    }
+
+    @Test
+    public void addCustomField_succeeds_if_valid_dropDownType() {
+        CreateCustomFieldDTO customField = getCreateCustomFieldDto(CreateCustomFieldDTO.TypeEnum.DROP_DOWN_LIST,
+                CreateCustomFieldDTO.DataTypeEnum.STRING);
+        when(customFieldRepository.findFirstByName(anyString())).thenReturn(Optional.empty());
+        when(customFieldTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getDropDownTypeEntity()));
+        when(customFieldDataTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getStringDataTypeEntity()));
+
+        ResponseEntity<Void> res = customFieldService.addCustomField(customField);
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        verify(customFieldRepository).save(customFieldCaptor.capture());
+        CustomFieldEntity savedCustomField = customFieldCaptor.getValue();
+        assertEquals(savedCustomField.getName(), customField.getName());
+
+        verify(customFieldOptionRepository).saveAll(customFieldOptionListCaptor.capture());
+        Iterable<CustomFieldOptionEntity> savedCustomFieldOptions = customFieldOptionListCaptor.getValue();
+        assertEquals(IterableUtil.sizeOf(savedCustomFieldOptions), customField.getOptions().size());
+    }
+
+    @Test
+    public void addCustomField_succeeds_if_valid_textField_string() {
+        CreateCustomFieldDTO customField = getCreateCustomFieldDto(CreateCustomFieldDTO.TypeEnum.TEXT_FIELD,
+                CreateCustomFieldDTO.DataTypeEnum.STRING);
+        when(customFieldRepository.findFirstByName(anyString())).thenReturn(Optional.empty());
+        when(customFieldTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getTextFieldTypeEntity()));
+        when(customFieldDataTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getStringDataTypeEntity()));
+
+        ResponseEntity<Void> res = customFieldService.addCustomField(customField);
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        verify(customFieldRepository).save(customFieldCaptor.capture());
+        CustomFieldEntity savedCustomField = customFieldCaptor.getValue();
+        assertEquals(savedCustomField.getName(), customField.getName());
+
+        verify(customFieldOptionRepository, never()).saveAll(customFieldOptionListCaptor.capture());
+    }
+
+    @Test
+    public void addCustomField_succeeds_if_valid_textField_json() {
+        CreateCustomFieldDTO customField = getCreateCustomFieldDto(CreateCustomFieldDTO.TypeEnum.TEXT_FIELD,
+                CreateCustomFieldDTO.DataTypeEnum.JSON);
+        when(customFieldRepository.findFirstByName(anyString())).thenReturn(Optional.empty());
+        when(customFieldTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getTextFieldTypeEntity()));
+        when(customFieldDataTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getJsonDataTypeEntity()));
+
+        ResponseEntity<Void> res = customFieldService.addCustomField(customField);
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        verify(customFieldRepository).save(customFieldCaptor.capture());
+        CustomFieldEntity savedCustomField = customFieldCaptor.getValue();
+        assertEquals(savedCustomField.getName(), customField.getName());
+
+        verify(customFieldOptionRepository, never()).saveAll(customFieldOptionListCaptor.capture());
+    }
+
+    @Test
+    public void addCustomField_succeeds_if_valid_textField_dateTime() {
+        CreateCustomFieldDTO customField = getCreateCustomFieldDto(CreateCustomFieldDTO.TypeEnum.TEXT_FIELD,
+                CreateCustomFieldDTO.DataTypeEnum.DATETIME);
+        when(customFieldRepository.findFirstByName(anyString())).thenReturn(Optional.empty());
+        when(customFieldTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getTextFieldTypeEntity()));
+        when(customFieldDataTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getDateTimeDataTypeEntity()));
+
+        ResponseEntity<Void> res = customFieldService.addCustomField(customField);
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        verify(customFieldRepository).save(customFieldCaptor.capture());
+        CustomFieldEntity savedCustomField = customFieldCaptor.getValue();
+        assertEquals(savedCustomField.getName(), customField.getName());
+
+        verify(customFieldOptionRepository, never()).saveAll(customFieldOptionListCaptor.capture());
+    }
+
+    @Test
+    public void addCustomField_succeeds_if_valid_textField_int() {
+        CreateCustomFieldDTO customField = getCreateCustomFieldDto(CreateCustomFieldDTO.TypeEnum.TEXT_FIELD,
+                CreateCustomFieldDTO.DataTypeEnum.INT);
+        when(customFieldRepository.findFirstByName(anyString())).thenReturn(Optional.empty());
+        when(customFieldTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getTextFieldTypeEntity()));
+        when(customFieldDataTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getIntDataTypeEntity()));
+
+        ResponseEntity<Void> res = customFieldService.addCustomField(customField);
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        verify(customFieldRepository).save(customFieldCaptor.capture());
+        CustomFieldEntity savedCustomField = customFieldCaptor.getValue();
+        assertEquals(savedCustomField.getName(), customField.getName());
+
+        verify(customFieldOptionRepository, never()).saveAll(customFieldOptionListCaptor.capture());
+    }
+
+    @Test
+    public void addCustomField_fails_if_name_taken() {
+        CreateCustomFieldDTO customField = getCreateCustomFieldDto(CreateCustomFieldDTO.TypeEnum.DROP_DOWN_LIST,
+                CreateCustomFieldDTO.DataTypeEnum.STRING);
+        when(customFieldRepository.findFirstByName(anyString())).thenReturn(Optional.of(getCustomFieldEntity()));
+
+        Exception exception = assertThrows(BusinessLogicException.class, () ->
+                customFieldService.addCustomField(customField));
+
+        assertEquals(exception.getMessage(), "A custom field with this name already exists.");
+    }
+
+    @Test
+    public void addCustomField_fails_if_type_invalid() {
+        CreateCustomFieldDTO customField = getCreateCustomFieldDto(CreateCustomFieldDTO.TypeEnum.DROP_DOWN_LIST,
+                CreateCustomFieldDTO.DataTypeEnum.STRING);
+        when(customFieldTypeRepository.findFirstByType(any())).thenReturn(Optional.empty());
+        when(customFieldDataTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getStringDataTypeEntity()));
+
+        Exception exception = assertThrows(ResourceNotFoundException.class, () ->
+                customFieldService.addCustomField(customField));
+
+        assertEquals(exception.getMessage(), "Custom field type not found!");
+    }
+
+    @Test
+    public void addCustomField_fails_if_dataType_invalid() {
+        CreateCustomFieldDTO customField = getCreateCustomFieldDto(CreateCustomFieldDTO.TypeEnum.DROP_DOWN_LIST,
+                CreateCustomFieldDTO.DataTypeEnum.STRING);
+        when(customFieldTypeRepository.findFirstByType(any())).thenReturn(Optional.of(getDropDownTypeEntity()));
+        when(customFieldDataTypeRepository.findFirstByType(any())).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(ResourceNotFoundException.class, () ->
+                customFieldService.addCustomField(customField));
+
+        assertEquals(exception.getMessage(), "Custom field data type not found!");
+    }
+
+    @Test
+    public void updateCustomField_succeeds_if_valid_dropdown() {
+        UpdateCustomFieldDTO customField = getUpdateCustomFieldDto();
+        CustomFieldEntity customFieldEntity = getCustomFieldEntity();
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customFieldEntity));
+
+        ResponseEntity<Void> res = customFieldService.updateCustomField(customFieldEntity.getId(), customField);
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        verify(customFieldRepository).save(customFieldCaptor.capture());
+        CustomFieldEntity savedCustomField = customFieldCaptor.getValue();
+        assertEquals(savedCustomField.getName(), customField.getName());
+        verify(customFieldOptionRepository).deleteAll(any());
+        verify(customFieldOptionRepository).saveAll(customFieldOptionListCaptor.capture());
+        Iterable<CustomFieldOptionEntity> savedOptions = customFieldOptionListCaptor.getValue();
+        assertEquals(IterableUtil.sizeOf(savedOptions), customField.getOptions().size());
+    }
+
+    @Test
+    public void updateCustomField_succeeds_if_valid_non_dropdown() {
+        CustomFieldEntity customFieldEntity = getCustomFieldEntity();
+        customFieldEntity.setType(getTextFieldTypeEntity());
+        customFieldEntity.setOptions(Collections.emptyList());
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customFieldEntity));
+        UpdateCustomFieldDTO customField = getUpdateCustomFieldDto();
+
+        ResponseEntity<Void> res = customFieldService.updateCustomField(customFieldEntity.getId(), customField);
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        verify(customFieldRepository).save(customFieldCaptor.capture());
+        CustomFieldEntity savedCustomField = customFieldCaptor.getValue();
+        assertEquals(savedCustomField.getName(), customField.getName());
+
+        verify(customFieldOptionRepository).deleteAll(any());
+        verify(customFieldOptionRepository, never()).saveAll(customFieldOptionListCaptor.capture());
+    }
+
+    @Test
+    public void updateCustomField_fails_if_field_does_not_exist() {
+        UpdateCustomFieldDTO customField = getUpdateCustomFieldDto();
+        CustomFieldEntity customFieldEntity = getCustomFieldEntity();
+        when(customFieldRepository.findById(any())).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(ResourceNotFoundException.class, () ->
+                customFieldService.updateCustomField(customFieldEntity.getId(), customField));
+        assertEquals(exception.getMessage(), "Custom field not found!");
+    }
+
+    @Test
+    public void updateCustom_field_fails_if_name_taken() {
+        UpdateCustomFieldDTO customField = getUpdateCustomFieldDto();
+        CustomFieldEntity customFieldEntity = getCustomFieldEntity();
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customFieldEntity));
+        when(customFieldRepository.findFirstByNameAndIdNot(anyString(), any()))
+                .thenReturn(Optional.of(customFieldEntity));
+
+        Exception exception = assertThrows(BusinessLogicException.class, () ->
+                customFieldService.updateCustomField(customFieldEntity.getId(), customField));
+        assertEquals(exception.getMessage(), "A custom field already exists with that name.");
+    }
+
+    @Test
+    public void deleteCustomField_succeeds_if_field_exists_non_dropdown() {
+        CustomFieldEntity customFieldEntity = getCustomFieldEntity();
+        customFieldEntity.setType(getTextFieldTypeEntity());
+        customFieldEntity.setOptions(Collections.emptyList());
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customFieldEntity));
+        when(userCustomFieldRepository.findAllByCustomField(any())).thenReturn(List.of(getUserCustomFieldEntity()));
+
+        ResponseEntity<Void> res = customFieldService.deleteCustomField(customFieldEntity.getId());
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        verify(userCustomFieldRepository).deleteAll(any());
+        verify(customFieldOptionRepository).deleteAll(any());
+        verify(customFieldRepository).delete(customFieldCaptor.capture());
+        CustomFieldEntity customField = customFieldCaptor.getValue();
+        assertEquals(customField.getId(), customFieldEntity.getId());
+    }
+
+    @Test
+    public void deleteCustomField_succeeds_if_field_exists_dropdown() {
+        CustomFieldEntity customFieldEntity = getCustomFieldEntity();
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customFieldEntity));
+        when(userCustomFieldRepository.findAllByCustomField(any())).thenReturn(List.of(getUserCustomFieldEntity()));
+
+        ResponseEntity<Void> res = customFieldService.deleteCustomField(customFieldEntity.getId());
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+        verify(userCustomFieldRepository).deleteAll(any());
+        verify(customFieldOptionRepository).deleteAll(any());
+        verify(customFieldRepository).delete(customFieldCaptor.capture());
+        CustomFieldEntity customField = customFieldCaptor.getValue();
+        assertEquals(customField.getId(), customFieldEntity.getId());
+    }
+
+    @Test
+    public void deleteCustomField_fails_if_field_does_not_exist() {
+        when(customFieldRepository.findById(any())).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(ResourceNotFoundException.class, () ->
+                customFieldService.deleteCustomField(UUID.randomUUID()));
+        assertEquals(exception.getMessage(), "Custom field not found!");
+    }
+
+    @Test
+    public void updateCustomFieldOptions_succeeds_if_valid() {
+        CustomFieldEntity customField = getCustomFieldEntity();
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customField));
+        List<CreateOrUpdateCustomFieldOptionDTO> options = List.of(getCreateOrUpdateCustomFieldOptionDto());
+
+        ResponseEntity<Void> res = customFieldService.updateCustomFieldOptions(customField.getId(), options);
+
+        assertEquals(res.getStatusCode(), HttpStatus.OK);
+
+        verify(customFieldOptionRepository).deleteAll(any());
+        verify(customFieldOptionRepository).saveAll(customFieldOptionListCaptor.capture());
+        Iterable<CustomFieldOptionEntity> savedCustomFieldOptions = customFieldOptionListCaptor.getValue();
+        assertEquals(IterableUtil.sizeOf(savedCustomFieldOptions), options.size());
+    }
+
+    @Test
+    public void updateCustomFieldOptions_fails_if_no_options() {
+        Exception exception = assertThrows(BusinessLogicException.class, () ->
+                customFieldService.updateCustomFieldOptions(UUID.randomUUID(), Collections.emptyList()));
+        assertEquals(exception.getMessage(), "No options were passed in.");
+    }
+
+    @Test
+    public void updateCustomFieldOptions_fails_if_field_does_not_exist() {
+        when(customFieldRepository.findById(any())).thenReturn(Optional.empty());
+        List<CreateOrUpdateCustomFieldOptionDTO> options = List.of(getCreateOrUpdateCustomFieldOptionDto());
+
+        Exception exception = assertThrows(ResourceNotFoundException.class, () ->
+                customFieldService.updateCustomFieldOptions(UUID.randomUUID(), options));
+        assertEquals(exception.getMessage(), "Custom field not found!");
+    }
+
+    @Test
+    public void updateCustomFieldOptions_fails_if_field_is_not_dropDown() {
+        CustomFieldEntity customField = getCustomFieldEntity();
+        customField.setType(getTextFieldTypeEntity());
+        when(customFieldRepository.findById(any())).thenReturn(Optional.of(customField));
+        List<CreateOrUpdateCustomFieldOptionDTO> options = List.of(getCreateOrUpdateCustomFieldOptionDto());
+
+        Exception exception = assertThrows(BusinessLogicException.class, () ->
+                customFieldService.updateCustomFieldOptions(UUID.randomUUID(), options));
+        assertEquals(exception.getMessage(), "The custom field is not a drop-down type.");
+    }
+
+    private UserCustomFieldEntity getUserCustomFieldEntity() {
+        CustomFieldOptionEntity option = new CustomFieldOptionEntity();
+        option.setId(UUID.randomUUID());
+        option.setOptionValue("VALUE_1");
+        option.setDisplayText("Value 1");
+
+        CustomFieldEntity customFieldEntity = new CustomFieldEntity();
+        customFieldEntity.setId(UUID.randomUUID());
+        customFieldEntity.setName("CUSTOM_FIELD_1");
+        customFieldEntity.setType(getDropDownTypeEntity());
+        customFieldEntity.setDataType(getStringDataTypeEntity());
+        customFieldEntity.setDisplayText("Custom Field 1");
+        customFieldEntity.setOptions(List.of(option));
+
+        UserCustomFieldEntity userCustomFieldEntity = new UserCustomFieldEntity();
+        userCustomFieldEntity.setId(UUID.randomUUID());
+        userCustomFieldEntity.setCustomField(customFieldEntity);
+        userCustomFieldEntity.setCustomFieldValueString("TEST1");
+
+        return userCustomFieldEntity;
+    }
+
+    private CreateCustomFieldDTO getCreateCustomFieldDto(CreateCustomFieldDTO.TypeEnum type,
+                                                         CreateCustomFieldDTO.DataTypeEnum dataType) {
+        CreateCustomFieldDTO customField = new CreateCustomFieldDTO();
+        customField.setName("CUSTOM_FIELD_1");
+        customField.setDisplayText("Custom Field 1");
+        customField.setType(type);
+        customField.setDataType(dataType);
+        if (type.compareTo(CreateCustomFieldDTO.TypeEnum.DROP_DOWN_LIST) == 0) {
+            CreateOrUpdateCustomFieldOptionDTO option = new CreateOrUpdateCustomFieldOptionDTO();
+            option.setOptionValue("VALUE_1");
+            option.setDisplayText("Value 1");
+            customField.setOptions(List.of(option));
+        }
+        return customField;
+    }
+
+    private UpdateCustomFieldDTO getUpdateCustomFieldDto() {
+        UpdateCustomFieldDTO customField = new UpdateCustomFieldDTO();
+        customField.setName("CUSTOM_FIELD_1");
+        customField.setDisplayText("Custom Field 1");
+        CreateOrUpdateCustomFieldOptionDTO option = new CreateOrUpdateCustomFieldOptionDTO();
+        option.setOptionValue("VALUE_1");
+        option.setDisplayText("Value 1");
+        customField.setOptions(List.of(option));
+        return customField;
+    }
+
+    private CustomFieldTypeEntity getDropDownTypeEntity() {
+        CustomFieldTypeEntity customFieldTypeEntity = new CustomFieldTypeEntity();
+        customFieldTypeEntity.setId(UUID.fromString("a80a48b5-2995-4c54-9bd5-ebc258fab4ba"));
+        customFieldTypeEntity.setType("drop_down_list");
+        return customFieldTypeEntity;
+    }
+
+    private CustomFieldTypeEntity getTextFieldTypeEntity() {
+        CustomFieldTypeEntity customFieldTypeEntity = new CustomFieldTypeEntity();
+        customFieldTypeEntity.setId(UUID.fromString("5fc38fee-e8f5-11ec-8fea-0242ac120002"));
+        customFieldTypeEntity.setType("text_field");
+        return customFieldTypeEntity;
+    }
+
+    private CustomFieldDataTypeEntity getStringDataTypeEntity() {
+        CustomFieldDataTypeEntity customFieldDataTypeEntity = new CustomFieldDataTypeEntity();
+        customFieldDataTypeEntity.setId(UUID.fromString("3e724ddf-4d09-452b-ae98-a8e3a76af19c"));
+        customFieldDataTypeEntity.setType("string");
+        return customFieldDataTypeEntity;
+    }
+
+    private CustomFieldDataTypeEntity getIntDataTypeEntity() {
+        CustomFieldDataTypeEntity customFieldDataTypeEntity = new CustomFieldDataTypeEntity();
+        customFieldDataTypeEntity.setId(UUID.fromString("7c6e4de3-5461-4a38-bdf8-2f853c50e3a3"));
+        customFieldDataTypeEntity.setType("int");
+        return customFieldDataTypeEntity;
+    }
+
+    private CustomFieldDataTypeEntity getJsonDataTypeEntity() {
+        CustomFieldDataTypeEntity customFieldDataTypeEntity = new CustomFieldDataTypeEntity();
+        customFieldDataTypeEntity.setId(UUID.fromString("69af3a92-b6d6-4b6a-90e5-51304cba887c"));
+        customFieldDataTypeEntity.setType("json");
+        return customFieldDataTypeEntity;
+    }
+
+    private CustomFieldDataTypeEntity getDateTimeDataTypeEntity() {
+        CustomFieldDataTypeEntity customFieldDataTypeEntity = new CustomFieldDataTypeEntity();
+        customFieldDataTypeEntity.setId(UUID.fromString("5d01d9e3-f8a8-42e3-877c-b743bff79e7f"));
+        customFieldDataTypeEntity.setType("datetime");
+        return customFieldDataTypeEntity;
+    }
+
+    private CustomFieldEntity getCustomFieldEntity() {
+        UserCustomFieldEntity userCustomFieldEntity = getUserCustomFieldEntity();
+        return userCustomFieldEntity.getCustomField();
+    }
+
+    private CreateOrUpdateCustomFieldOptionDTO getCreateOrUpdateCustomFieldOptionDto() {
+        CreateOrUpdateCustomFieldOptionDTO option = new CreateOrUpdateCustomFieldOptionDTO();
+        option.setOptionValue("VALUE_1");
+        option.setDisplayText("Value 1");
+        return option;
+    }
+}

--- a/service/src/test/java/io/nuvalence/user/management/api/service/service/UserServiceTest.java
+++ b/service/src/test/java/io/nuvalence/user/management/api/service/service/UserServiceTest.java
@@ -3,7 +3,11 @@ package io.nuvalence.user.management.api.service.service;
 import io.nuvalence.user.management.api.service.cerbos.CerbosClient;
 import io.nuvalence.user.management.api.service.config.exception.BusinessLogicException;
 import io.nuvalence.user.management.api.service.config.exception.ResourceNotFoundException;
+import io.nuvalence.user.management.api.service.entity.CustomFieldDataTypeEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldEntity;
+import io.nuvalence.user.management.api.service.entity.CustomFieldTypeEntity;
 import io.nuvalence.user.management.api.service.entity.RoleEntity;
+import io.nuvalence.user.management.api.service.entity.UserCustomFieldEntity;
 import io.nuvalence.user.management.api.service.entity.UserEntity;
 import io.nuvalence.user.management.api.service.entity.UserRoleEntity;
 import io.nuvalence.user.management.api.service.generated.models.RoleDTO;
@@ -11,6 +15,7 @@ import io.nuvalence.user.management.api.service.generated.models.UserCreationReq
 import io.nuvalence.user.management.api.service.generated.models.UserDTO;
 import io.nuvalence.user.management.api.service.generated.models.UserRoleDTO;
 import io.nuvalence.user.management.api.service.repository.RoleRepository;
+import io.nuvalence.user.management.api.service.repository.UserCustomFieldRepository;
 import io.nuvalence.user.management.api.service.repository.UserRepository;
 import io.nuvalence.user.management.api.service.repository.UserRoleRepository;
 import org.junit.jupiter.api.Test;
@@ -37,6 +42,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 public class UserServiceTest {
 
     @Mock
@@ -47,6 +53,9 @@ public class UserServiceTest {
 
     @Mock
     private UserRoleRepository userRoleRepository;
+
+    @Mock
+    private UserCustomFieldRepository userCustomFieldRepository;
 
     @Mock
     private CerbosClient client;
@@ -134,8 +143,12 @@ public class UserServiceTest {
     public void deleteUser_deletesUserCorrectly() {
         List<UserRoleEntity> userRoleEntities = List.of(createUserRoleEntity());
         UserEntity userEntity = createUserEntity();
+        UserCustomFieldEntity userCustomFieldEntity = createUserCustomFieldEntity();
+        userCustomFieldEntity.setUser(userEntity);
+        List<UserCustomFieldEntity> userCustomFieldEntities = List.of(userCustomFieldEntity);
 
         when(userRoleRepository.findAllByUserId(userEntity.getId())).thenReturn(userRoleEntities);
+        when(userCustomFieldRepository.findAllByUserId(userEntity.getId())).thenReturn(userCustomFieldEntities);
         when(userRepository.findById(userEntity.getId())).thenReturn(Optional.of(userEntity));
 
         ResponseEntity<Void> res = userService.deleteUser(userEntity.getId());
@@ -384,6 +397,30 @@ public class UserServiceTest {
         userEntity.setDisplayName("John Locke");
         userEntity.setExternalId("TestExternalId1234");
         return userEntity;
+    }
+
+    private UserCustomFieldEntity createUserCustomFieldEntity() {
+        CustomFieldTypeEntity customFieldTypeEntity = new CustomFieldTypeEntity();
+        customFieldTypeEntity.setId(UUID.fromString("a80a48b5-2995-4c54-9bd5-ebc258fab4ba"));
+        customFieldTypeEntity.setType("drop_down_list");
+
+        CustomFieldDataTypeEntity dataType = new CustomFieldDataTypeEntity();
+        dataType.setId(UUID.fromString("3e724ddf-4d09-452b-ae98-a8e3a76af19c"));
+        dataType.setType("string");
+
+        CustomFieldEntity customFieldEntity = new CustomFieldEntity();
+        customFieldEntity.setId(UUID.randomUUID());
+        customFieldEntity.setName("CUSTOM_FIELD_1");
+        customFieldEntity.setType(customFieldTypeEntity);
+        customFieldEntity.setDataType(dataType);
+        customFieldEntity.setDisplayText("Custom Field 1");
+
+        UserCustomFieldEntity userCustomFieldEntity = new UserCustomFieldEntity();
+        userCustomFieldEntity.setId(UUID.randomUUID());
+        userCustomFieldEntity.setCustomField(customFieldEntity);
+        userCustomFieldEntity.setCustomFieldValueString("TEST1");
+
+        return userCustomFieldEntity;
     }
 
     private UserRoleEntity createUserRoleEntity() {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -59,6 +59,32 @@ paths:
           description: "You are unauthorized to make this request"
         "404":
           description: "User not found"
+  /user/{id}/custom-field:
+    put:
+      tags:
+        - "user"
+      summary: "Sets the value of a custom field with the provided value."
+      operationId: "updateUserCustomFieldValue"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "id of the user to update the custom field for."
+          required: true
+          type: "string"
+          format: uuid
+        - name: body
+          in: body
+          description: "custom field object"
+          required: true
+          schema:
+            $ref: "#/definitions/CreateOrUpdateUserCustomFieldDTO"
+      responses:
+        "200":
+          description: "successful operation"
+        "401":
+          description: "You are unauthorized to make this request"
+        "404":
+          description: "User not found"
   /user/email/{email}:
     get:
       tags:
@@ -445,6 +471,152 @@ paths:
             items:
               $ref: "#/definitions/LanguageDTO"
 
+  /custom-fields:
+    get:
+      tags:
+        - "custom-fields"
+      summary: "Returns all custom fields."
+      operationId: "getAllCustomFields"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/CustomFieldDTO"
+        "401":
+          description: "You are unauthorized to make this request"
+        "404":
+          description: "Custom fields not found"
+    post:
+      tags:
+        - "custom-fields"
+      summary: "Creates a new custom field."
+      operationId: "addCustomField"
+      parameters:
+        - name: body
+          in: body
+          description: "custom field object"
+          required: true
+          schema:
+            $ref: "#/definitions/CreateCustomFieldDTO"
+      responses:
+        "200":
+          description: "successful operation"
+        "401":
+          description: "You are unauthorized to make this request"
+  /custom-fields/{id}:
+    get:
+      tags:
+        - "custom-fields"
+      summary: "Gets a custom field."
+      operationId: "getCustomFieldById"
+      parameters:
+        - name: "id"
+          in: path
+          description: "ID for custom field to update."
+          type: "string"
+          required: true
+          format: uuid
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/CustomFieldDTO"
+        "401":
+          description: "You are unauthorized to make this request"
+    put:
+      tags:
+        - "custom-fields"
+      summary: "Updates an existing custom field."
+      operationId: "updateCustomField"
+      parameters:
+        - name: "id"
+          in: path
+          description: "ID for custom field to update."
+          type: "string"
+          required: true
+          format: uuid
+        - name: body
+          in: body
+          description: "custom field object"
+          required: true
+          schema:
+            $ref: "#/definitions/UpdateCustomFieldDTO"
+      responses:
+        "200":
+          description: "successful operation"
+        "401":
+          description: "You are unauthorized to make this request"
+    delete:
+      tags:
+        - "custom-fields"
+      summary: "Deletes an existing custom field."
+      operationId: "deleteCustomField"
+      parameters:
+        - name: "id"
+          in: path
+          description: "ID for custom field to delete."
+          type: "string"
+          required: true
+          format: uuid
+      responses:
+        "200":
+          description: "successful operation"
+        "401":
+          description: "You are unauthorized to make this request"
+  /custom-fields/{id}/options:
+    get:
+      tags:
+        - "custom-fields"
+      summary: "Gets the options for a custom field."
+      operationId: "getOptionsForCustomField"
+      parameters:
+        - name: "id"
+          in: path
+          description: "ID for the custom field to find options of."
+          type: "string"
+          required: true
+          format: uuid
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/CustomFieldOptionDTO"
+        "401":
+          description: "You are unauthorized to make this request"
+        "404":
+          description: "Custom field not found"
+    put:
+      tags:
+        - "custom-fields"
+      summary: "Updates the list of options for a custom field."
+      operationId: "updateCustomFieldOptions"
+      parameters:
+        - name: "id"
+          in: path
+          description: "ID for the custom field to find options of."
+          type: "string"
+          required: true
+          format: uuid
+        - name: body
+          in: body
+          description: "custom field object"
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/CreateOrUpdateCustomFieldOptionDTO"
+      responses:
+        "200":
+          description: "successful operation"
+        "401":
+          description: "You are unauthorized to make this request"
+        "404":
+          description: "Custom field not found"
+
   /validate/user-permission:
     get:
       tags:
@@ -487,6 +659,7 @@ definitions:
     type: string
     enum: &CUSTOM_FIELD_TYPE
       - drop_down_list
+      - text_field
   AllRoles:
     type: array
     items:
@@ -645,10 +818,10 @@ definitions:
         type: string
       type:
         type: string
-        enum: [drop_down_list]
+        enum: *CUSTOM_FIELD_TYPE
       dataType:
         type: string
-        enum: [string, int, json, datetime]
+        enum: *CUSTOM_FIELD_DATA_TYPE
       options:
         type: array
         items:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -476,6 +476,17 @@ paths:
           description: "You are not authorized to make this request"
 
 definitions:
+  CustomFieldDataType:
+    type: string
+    enum: &CUSTOM_FIELD_DATA_TYPE
+      - string
+      - int
+      - json
+      - datetime
+  CustomFieldType:
+    type: string
+    enum: &CUSTOM_FIELD_TYPE
+      - drop_down_list
   AllRoles:
     type: array
     items:
@@ -512,6 +523,10 @@ definitions:
       preferences:
         type: object
         $ref: '#/definitions/UserPreferenceDTO'
+      customFields:
+        type: array
+        items:
+          $ref: '#/definitions/UserCustomFieldDTO'
   RoleDTO:
     type: object
     required:
@@ -575,6 +590,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/RoleDTO'
+      customFields:
+        type: array
+        items:
+          $ref: '#/definitions/CreateOrUpdateUserCustomFieldDTO'
   ValidatePermissionDTO:
     type: object
     required:
@@ -594,3 +613,114 @@ definitions:
       languageStandardId:
         type: string
         example: "en"
+  CustomFieldOptionDTO:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      optionValue:
+        type: string
+      displayText:
+        type: string
+  CreateOrUpdateCustomFieldOptionDTO:
+    type: object
+    required:
+      - optionValue
+      - displayText
+    properties:
+      optionValue:
+        type: string
+      displayText:
+        type: string
+  CustomFieldDTO:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      name:
+        type: string
+      displayText:
+        type: string
+      type:
+        type: string
+        enum: [drop_down_list]
+      dataType:
+        type: string
+        enum: [string, int, json, datetime]
+      options:
+        type: array
+        items:
+          $ref: "#/definitions/CustomFieldOptionDTO"
+  UpdateCustomFieldDTO:
+    type: object
+    required:
+      - name
+      - displayText
+    properties:
+      name:
+        type: string
+      displayText:
+        type: string
+      options:
+        type: array
+        items:
+          $ref: "#/definitions/CreateOrUpdateCustomFieldOptionDTO"
+  CreateCustomFieldDTO:
+    type: object
+    required:
+      - name
+      - displayText
+      - type
+      - dataType
+    properties:
+      name:
+        type: string
+      displayText:
+        type: string
+      type:
+        type: string
+        enum: *CUSTOM_FIELD_TYPE
+      dataType:
+        type: string
+        enum: *CUSTOM_FIELD_DATA_TYPE
+      options:
+        type: array
+        items:
+          $ref: "#/definitions/CreateOrUpdateCustomFieldOptionDTO"
+  CreateOrUpdateUserCustomFieldDTO:
+    type: object
+    required:
+      - customFieldId
+    properties:
+      customFieldId:
+        type: string
+        format: uuid
+      value:
+        type: object
+  UserCustomFieldDTO:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      customFieldId:
+        type: string
+        format: uuid
+      type:
+        type: string
+        enum: *CUSTOM_FIELD_TYPE
+      dataType:
+        type: string
+        enum: *CUSTOM_FIELD_DATA_TYPE
+      name:
+        type: string
+      displayText:
+        type: string
+      value:
+        type: object
+      options:
+        type: array
+        items:
+          $ref: "#/definitions/CustomFieldOptionDTO"


### PR DESCRIPTION
## Description
This code is to add support for custom fields on users within the User API.

## Motivation and Context
This code is needed so that user fields specific to an engagement can be implemented via a custom field as opposed to adding the field to the user. This provides more flexibility.

## Areas for Focus
CustomFieldService was introduced and is where a bulk of the code for this branch lives, so special attention should be paid there.

## How Has This Been Tested?
This was tested via docker-compose and using postman to test the endpoints.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Patch
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (documentation only, will not require redeployment)
- [ ] Refactor or cleanup (functionality unchanged)
Minor
- [x] New feature (non-breaking change which adds functionality)
Major
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any do not apply, leave a description indicating why -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
<!-- - [ ] My change requires a version increment in gradle.properties -->
<!-- - [ ] My change requires redeployment of the API Gateway Deployment after the pipeline succeeds -->
- [x] I have confirmed all acceptance criteria defined by the story have been met